### PR TITLE
Allow a Task to be actioned it if EXTENDS an incomplete Task

### DIFF
--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1137,8 +1137,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         AND task_pool_actions.weight > 0
         OPTIONAL MATCH (task_pool)-[:EXTENDS]->(other_task:Task)
         WITH th,  task_pool, other_task, task_pool_actions
-        WHERE NOT (th)-[:ACTIONS]->(task_pool)
-        AND other_task.status = 'complete' OR other_task IS NULL
+        WHERE other_task.status = 'complete' OR other_task IS NULL
         // get the lowest priority
         WITH MIN(task_pool.priority) as min_priority
 
@@ -1149,8 +1148,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         AND task_pool.priority = min_priority
         OPTIONAL MATCH (task_pool)-[:EXTENDS]->(other_task:Task)
         WITH th,  task_pool, other_task, task_pool_actions
-        WHERE NOT (th)-[:ACTIONS]->(task_pool)
-        AND other_task.status = 'complete' OR other_task IS NULL
+        WHERE other_task.status = 'complete' OR other_task IS NULL
 
         // return the tasks       
         RETURN task_pool, task_pool_actions

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -846,9 +846,9 @@ class Neo4jStore(AlchemiscaleStateStore):
         A given compute task can be represented in any number of
         AlchemicalNetwork TaskHubs, or none at all.
 
-        If this Task has an EXTENDS relationship to another Task, that Task must
-        be 'complete' before this Task can be added to *any* TaskHub.
-
+        If this Task has an EXTENDS relationship to another Task, that Task will
+        also be added to the TaskHub. Logic in the claim_tasks method will
+        ensure that the Task is only claimed if the task it EXTENDS has been completed.
         """
         with self.transaction() as tx:
             actioned_sks = []

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1093,9 +1093,9 @@ class Neo4jStore(AlchemiscaleStateStore):
 
         This method will claim Tasks from a TaskHub according to the following process:
         1. `waiting` Tasks with the highest priority are selected for consideration.
-        2. Tasks with an `EXTENDS` relationship to an incomplete Task are dropped 
+        2. Tasks with an `EXTENDS` relationship to an incomplete Task are dropped
            from consideration.
-        3. Of those that remain, a Task is claimed stochastically based on the 
+        3. Of those that remain, a Task is claimed stochastically based on the
            `weight` of its ACTIONS relationship with the TaskHub.
 
         This process is repeated until `count` Tasks have been claimed.

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1124,7 +1124,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         1. `waiting` Tasks with the highest priority are selected for consideration.
         2. Tasks with an `EXTENDS` relationship to an incomplete Task are dropped from consideration.
         3. Of those that remain, a Task is claimed stochastically based on the `weight` of its ACTIONS relationship on the TaskHub.
-        
+
         This process is repeated until `count` Tasks have been claimed.
         If no Task is available, then `None` is given in its place.
 

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -17,7 +17,6 @@ import numpy as np
 import networkx as nx
 from gufe import AlchemicalNetwork, Transformation
 from gufe.tokenization import GufeTokenizable, GufeKey, JSON_HANDLER
-from gufe.storage.metadatastore import MetadataStore
 from py2neo import Graph, Node, Relationship, Subgraph
 from py2neo.database import Transaction
 from py2neo.matching import NodeMatcher

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -190,15 +190,14 @@ class TestClient:
         assert set(actioned_sks) == set(hub_task_sks)
         assert actioned_sks == task_sks[::-1]
 
-        # create extending tasks; try to action one of them
-        # this should yield `None` in results, since it shouldn't be possible to action these tasks
-        # if they extend a task that isn't 'complete'
+        # create extending tasks; these should be actioned to the
+        # taskhub but not claimable
         task_sks_e = user_client.create_tasks(
             transformation_sk, count=4, extends=task_sks[0]
         )
         actioned_sks_e = user_client.action_tasks(task_sks_e, network_sk)
 
-        assert all([i is None for i in actioned_sks_e])
+        assert set(task_sks_e) == set(actioned_sks_e)
 
     def test_cancel_tasks(
         self,

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -291,18 +291,11 @@ class TestClient:
         network_sk = user_client.get_scoped_key(an, scope_test)
         transformation_sk = user_client.get_scoped_key(transformation, scope_test)
 
-        # user client : create a tree of tasks for the transformation
+        # user client : create three independent tasks for the transformation
         tasks = user_client.create_tasks(transformation_sk, count=3)
-        for task in tasks:
-            tasks_2 = user_client.create_tasks(transformation_sk, extends=task, count=3)
-            for task2 in tasks_2:
-                user_client.create_tasks(transformation_sk, extends=task2, count=3)
 
         # user client : action the tasks for execution
         all_tasks = user_client.get_tasks(transformation_sk)
-        # all_tasks = reversed(list(nx.topological_sort(all_tasks_g)))
-
-        # only tasks that do not extend an incomplete task are actioned
         actioned_tasks = user_client.action_tasks(all_tasks, network_sk)
 
         # execute the actioned tasks and push results directly using statestore and object store

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -533,17 +533,12 @@ class TestNeo4jStore(TestStateStore):
         # create 10 tasks
         task_sks = [n4js.create_task(transformation_sk) for i in range(10)]
 
-        # import pdb
-        # pdb.set_trace()
-
         # action the tasks
         actioned = n4js.action_tasks(task_sks, taskhub_sk)
         assert len(actioned) == 10
-        # print(actioned)
 
         # get the full hub back; no particular order
         task_sks = n4js.get_taskhub_tasks(taskhub_sk)
-        # print(task_sks)
 
         # no particular order so must check that the sets are equal
         assert set(actioned) == set(task_sks)

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -632,9 +632,11 @@ class TestNeo4jStore(TestStateStore):
         claimed6 = n4js.claim_taskhub_tasks(taskhub_sk, "last task handler", count=2)
         assert claimed6 == [None] * 2
 
-    def test_claim_action_task_extends(
+    def test_action_claim_task_extends(
         self, n4js: Neo4jStore, network_tyk2, scope_test
     ):
+        # tests the ability to action and claim a set of tasks in an
+        # EXTENDS chain
         an = network_tyk2
         network_sk = n4js.create_network(an, scope_test)
         taskhub_sk: ScopedKey = n4js.create_taskhub(network_sk)
@@ -668,9 +670,59 @@ class TestNeo4jStore(TestStateStore):
         # complete the extends task
         n4js.set_task_complete(first_task)
 
-        # claim the next 9 tasks again
+        # claim the next task again
         claimed_task_sks = n4js.claim_taskhub_tasks(taskhub_sk, "task handler", count=1)
-        # oops the extends task is still running!
+        assert claimed_task_sks == collected_sks[1:2]
+
+    def test_action_claim_task_extends_non_extends(
+        self, n4js: Neo4jStore, network_tyk2, scope_test
+    ):
+        # tests the ability to action and claim a set of tasks that have a mix of
+        # EXTENDS and non-EXTENDS tasks
+        an = network_tyk2
+        network_sk = n4js.create_network(an, scope_test)
+        taskhub_sk: ScopedKey = n4js.create_taskhub(network_sk)
+
+        transformation = list(an.edges)[0]
+        transformation_sk = n4js.get_scoped_key(transformation, scope_test)
+
+        # create 10 tasks that extend in an EXTENDS chain
+        first_task = n4js.create_task(transformation_sk)
+        collected_sks = [first_task]
+        prev = first_task
+        for i in range(9):
+            curr = n4js.create_task(transformation_sk, extends=prev)
+            collected_sks.append(curr)
+            prev = curr
+
+        # create another two tasks that don't extend anything
+        extra_task_1 = n4js.create_task(transformation_sk)
+        extra_task_2 = n4js.create_task(transformation_sk)
+        extra_tasks = [extra_task_1, extra_task_2]
+        collected_sks.extend(extra_tasks)
+
+        # action the tasks
+        actioned_task_sks = n4js.action_tasks(collected_sks, taskhub_sk)
+        assert set(actioned_task_sks) == set(collected_sks)
+
+        # claim the first task **3** tasks, this set should be the first extends
+        # task and the two non-extends tasks
+        claimed_task_sks = n4js.claim_taskhub_tasks(taskhub_sk, "task handler", count=3)
+
+        assert set(claimed_task_sks) == set([first_task] + extra_tasks)
+
+        # claim the next 10 tasks
+        claimed_task_sks = n4js.claim_taskhub_tasks(
+            taskhub_sk, "task handler", count=10
+        )
+        # oops the extends task is still running and there should be no other tasks to grab
+        assert claimed_task_sks == [None] * 10
+
+        # complete the extends task
+        n4js.set_task_complete(first_task)
+
+        # claim the next task again
+        claimed_task_sks = n4js.claim_taskhub_tasks(taskhub_sk, "task handler", count=1)
         assert claimed_task_sks == collected_sks[1:2]
 
     def test_claim_task_byweight(self, n4js: Neo4jStore, network_tyk2, scope_test):

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -666,12 +666,12 @@ class TestNeo4jStore(TestStateStore):
         assert claimed_task_sks == [None] * 9
 
         # complete the extends task
-        n4js.set_task_complete(claimed_task_sks[0])
+        n4js.set_task_complete(first_task)
 
         # claim the next 9 tasks again
-        claimed_task_sks = n4js.claim_taskhub_tasks(taskhub_sk, "task handler", count=9)
+        claimed_task_sks = n4js.claim_taskhub_tasks(taskhub_sk, "task handler", count=1)
         # oops the extends task is still running!
-        assert claimed_task_sks == collected_sks[1:]
+        assert claimed_task_sks == collected_sks[1:2]
 
     def test_claim_task_byweight(self, n4js: Neo4jStore, network_tyk2, scope_test):
         an = network_tyk2

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -533,12 +533,17 @@ class TestNeo4jStore(TestStateStore):
         # create 10 tasks
         task_sks = [n4js.create_task(transformation_sk) for i in range(10)]
 
+        # import pdb
+        # pdb.set_trace()
+
         # action the tasks
         actioned = n4js.action_tasks(task_sks, taskhub_sk)
         assert len(actioned) == 10
+        # print(actioned)
 
         # get the full hub back; no particular order
         task_sks = n4js.get_taskhub_tasks(taskhub_sk)
+        # print(task_sks)
 
         # no particular order so must check that the sets are equal
         assert set(actioned) == set(task_sks)

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -749,10 +749,6 @@ class TestNeo4jStore(TestStateStore):
         layer_three_3 = n4js.create_task(transformation_sk, extends=layer_two_2)
         layer_three_4 = n4js.create_task(transformation_sk, extends=layer_two_2)
 
-        import pdb
-
-        pdb.set_trace()
-
         collected_sks = [
             first_task,
             layer_two_1,


### PR DESCRIPTION
Fixes #84 
- modified the `action_tasks` code to allow actioning of tasks via an `EXTENDS` relationship even if not complete 
- Equivalent changes to the `claim` code to only allow claiming of extends tasks if the preceding node is complete. 