### PR TITLE
Enforce alphanumeric, underscore, or only asterisk for Scope components 

### DIFF
--- a/alchemiscale/models.py
+++ b/alchemiscale/models.py
@@ -6,6 +6,7 @@ Data models --- :mod:`alchemiscale.models`
 from typing import Optional, Union
 from pydantic import BaseModel, Field, validator, root_validator
 from gufe.tokenization import GufeKey
+from re import fullmatch
 
 
 class Scope(BaseModel):
@@ -28,8 +29,14 @@ class Scope(BaseModel):
 
     @staticmethod
     def _validate_component(v, component):
-        if v is not None and "-" in v:
-            raise ValueError(f"'{component}' must not contain dashes ('-')")
+        # use regex to check that the component is alphanumeric or underscore
+        # and does not contain dashes and contains only a single asterisk.
+        # we require that there is a full match, so that the string is not
+        # allowed to contain any other characters.
+        if v is not None and not fullmatch(r"^[a-zA-Z0-9_]+|\*$", v):
+            raise ValueError(
+                f"'{component}' must be alphanumeric or underscore ('_') and must not contain dashes ('-')"
+            )
         elif v == "*":
             # if we're given an asterisk, cast this to `None` instead for
             # consistency

--- a/alchemiscale/tests/unit/test_models.py
+++ b/alchemiscale/tests/unit/test_models.py
@@ -72,6 +72,8 @@ def test_scope_superset_false(super_scope_str, sub_scope_str):
     "scope_string",
     [
         "*foo-*-*",
+        "*_foo-*-*",
+        "*-foo-*-*",
         "f-oo-bar-baz",
         "!@#$%^&-bar-baz",
         "☺☻♥♦♣-bar-baz",
@@ -79,6 +81,19 @@ def test_scope_superset_false(super_scope_str, sub_scope_str):
         "𝄞𝄢𝄪𝄫𝅘𝅥𝅮𝅥𝅲𝅳𝆺𝅥𝆹𝅥𝅮𝆺𝅥𝅮𝆹𝅥𝅯𝆺𝅥𝅯𝇁𝇂𝇃-bar-baz",
     ],
 )
-def test_scope_non_alphanumeric_or_underscore_invalid(scope_string):
+def test_scope_non_alphanumeric_invalid(scope_string):
     with pytest.raises(ValueError):
         scope = Scope.from_str(scope_string)
+
+
+@pytest.mark.parametrize(
+    "scope_string",
+    [
+        "a_b-*-*",
+        "a_b-c_d-*",
+        "a_b-c_d-e_f",
+        "org_1-campaign_A-project_I",
+    ],
+)
+def test_underscore_scopes_valid(scope_string):
+    scope = Scope.from_str(scope_string)

--- a/alchemiscale/tests/unit/test_models.py
+++ b/alchemiscale/tests/unit/test_models.py
@@ -66,3 +66,19 @@ def test_scope_superset_false(super_scope_str, sub_scope_str):
     super_scope = Scope.from_str(super_scope_str)
     sub_scope = Scope.from_str(sub_scope_str)
     assert not super_scope.is_superset(sub_scope)
+
+
+@pytest.mark.parametrize(
+    "scope_string",
+    [
+        "*foo-*-*",
+        "f-oo-bar-baz",
+        "!@#$%^&-bar-baz",
+        "☺☻♥♦♣-bar-baz",
+        ",.<>/?|-bar-baz",
+        "𝄞𝄢𝄪𝄫𝅘𝅥𝅮𝅥𝅲𝅳𝆺𝅥𝆹𝅥𝅮𝆺𝅥𝅮𝆹𝅥𝅯𝆺𝅥𝅯𝇁𝇂𝇃-bar-baz",
+    ],
+)
+def test_scope_non_alphanumeric_or_underscore_invalid(scope_string):
+    with pytest.raises(ValueError):
+        scope = Scope.from_str(scope_string)


### PR DESCRIPTION
Fixes #88 

Uses a regex to check that scope components are what we expect them to be. 