### PR TITLE
Add `required` to the CLI arguments used to spin up the `docker compose` instance

### DIFF
--- a/alchemiscale/cli.py
+++ b/alchemiscale/cli.py
@@ -312,7 +312,7 @@ def synchronous():
     ...
 
 
-@cli.group()
+@cli.group(help="Subcommands for the database")
 def database():
     ...
 
@@ -412,7 +412,7 @@ def scope(func):
     return scope(func)
 
 
-@cli.group()
+@cli.group(help="Subcommands for managing identities")
 def identity():
     ...
 

--- a/alchemiscale/cli.py
+++ b/alchemiscale/cli.py
@@ -82,6 +82,7 @@ def db_params(func):
         help="database URI",
         type=str,
         envvar="NEO4J_URL",
+        required=True,
         **SETTINGS_OPTION_KWARGS,
     )
     user = click.option(
@@ -89,6 +90,7 @@ def db_params(func):
         help="database user name",
         type=str,
         envvar="NEO4J_USER",
+        required=True,
         **SETTINGS_OPTION_KWARGS,
     )
     password = click.option(
@@ -96,6 +98,7 @@ def db_params(func):
         help="database password",
         type=str,
         envvar="NEO4J_PASS",
+        required=True,
         **SETTINGS_OPTION_KWARGS,
     )
     dbname = click.option(
@@ -163,15 +166,24 @@ def s3os_params(func):
         **SETTINGS_OPTION_KWARGS,
     )
     s3_bucket = click.option(
-        "--s3-bucket", type=str, envvar="AWS_S3_BUCKET", **SETTINGS_OPTION_KWARGS
+        "--s3-bucket",
+        type=str,
+        envvar="AWS_S3_BUCKET",
+        required=True,
+        **SETTINGS_OPTION_KWARGS,
     )
     s3_prefix = click.option(
-        "--s3-prefix", type=str, envvar="AWS_S3_PREFIX", **SETTINGS_OPTION_KWARGS
+        "--s3-prefix",
+        type=str,
+        envvar="AWS_S3_PREFIX",
+        required=True,
+        **SETTINGS_OPTION_KWARGS,
     )
     default_region = click.option(
         "--default-region",
         type=str,
         envvar="AWS_DEFAULT_REGION",
+        required=True,
         **SETTINGS_OPTION_KWARGS,
     )
     return access_key_id(


### PR DESCRIPTION
Fixes #75 

As far as I can tell I have added required to the CLI arguments that are compulsory for spinning up the instance. I couldn't verify that `docker compose` worked as designed as I don't have the `aws` and `cloudwatch` keys. Perhaps @mikemhenry can confirm? 

Other than that should be good to go. 