### PR TITLE
Fixed version mismatch of alchemiscale in conda environments

### DIFF
--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -30,5 +30,5 @@ dependencies:
   - pip:
     - nest_asyncio
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.3
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -26,5 +26,5 @@ dependencies:
 
   - pip:
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.3
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -44,5 +44,5 @@ dependencies:
 
   - pip:
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.3
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc


### PR DESCRIPTION
Updated the alchemiscale version from 0.1.3 to 0.1.4 in the conda environments.

Fixes #164 