### PR TITLE
Updated prod-oriented conda envs to use latest openfe, gufe, and python 3.11

### DIFF
--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -5,11 +5,11 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.10
+  - python =3.11
 
   # alchemiscale dependencies
-  - gufe=0.9.1
-  - openfe=0.11.0
+  - gufe=0.9.4
+  - openfe=0.14.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -30,5 +30,5 @@ dependencies:
   - pip:
     - nest_asyncio
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.2.0
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -9,7 +9,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=0.9.4
-  - openfe=0.14.0
+  - openfe=0.13.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -9,7 +9,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=0.9.4
-  - openfe=0.14.0
+  - openfe=0.13.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -4,12 +4,12 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.10
+  - python =3.11
   - cudatoolkit <=11.7  # many actual compute resources are not yet compatible with cudatoolkit >=11.8
 
   # alchemiscale dependencies
-  - gufe=0.9.1
-  - openfe=0.11.0
+  - gufe=0.9.4
+  - openfe=0.14.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -26,5 +26,5 @@ dependencies:
 
   - pip:
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.2.0
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -5,11 +5,11 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.10
+  - python =3.11
 
   # alchemiscale dependencies
-  - gufe=0.9.1
-  - openfe=0.11.0
+  - gufe=0.9.4
+  - openfe=0.14.0
   - requests
   - click
   - pydantic<2.0

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -44,5 +44,5 @@ dependencies:
 
   - pip:
     - async_lru
-    - git+https://github.com/openforcefield/alchemiscale.git@v0.1.4
+    - git+https://github.com/openforcefield/alchemiscale.git@v0.2.0
     - git+https://github.com/choderalab/perses.git@protocol-neqcyc

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -9,7 +9,7 @@ dependencies:
 
   # alchemiscale dependencies
   - gufe=0.9.4
-  - openfe=0.14.0
+  - openfe=0.13.0
   - requests
   - click
   - pydantic<2.0

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -22,7 +22,7 @@ If this doesn’t work, clone alchemiscale from Github, and install from there::
 
     $ git clone https://github.com/openforcefield/alchemiscale.git
     $ cd alchemiscale
-    $ git checkout v0.1.4-1
+    $ git checkout v0.2.0
 
     $ conda env create -f devtools/conda-envs/alchemiscale-client.yml
 


### PR DESCRIPTION
Testing on alchemiscale.org QA to see if migrations required to avoid breakage of old data models in state and object stores.
