### PR TITLE
Set minimum for openmmforcefields version in conda envs to 0.12.0

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -29,6 +29,7 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -29,7 +29,6 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-          - "3.11"
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -5,7 +5,7 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.11
+  - python =3.10
 
   # alchemiscale dependencies
   - gufe=0.9.4

--- a/devtools/conda-envs/alchemiscale-client.yml
+++ b/devtools/conda-envs/alchemiscale-client.yml
@@ -10,6 +10,7 @@ dependencies:
   # alchemiscale dependencies
   - gufe=0.9.4
   - openfe=0.13.0
+  - openmmforcefields>=0.12.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -10,6 +10,7 @@ dependencies:
   # alchemiscale dependencies
   - gufe=0.9.4
   - openfe=0.13.0
+  - openmmforcefields>=0.12.0
   - requests
   - click
   - httpx

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -4,7 +4,7 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.11
+  - python =3.10
   - cudatoolkit <=11.7  # many actual compute resources are not yet compatible with cudatoolkit >=11.8
 
   # alchemiscale dependencies

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -5,7 +5,7 @@ channels:
   - openeye
 dependencies:
   - pip
-  - python =3.11
+  - python =3.10
 
   # alchemiscale dependencies
   - gufe=0.9.4

--- a/devtools/conda-envs/alchemiscale-server.yml
+++ b/devtools/conda-envs/alchemiscale-server.yml
@@ -10,6 +10,7 @@ dependencies:
   # alchemiscale dependencies
   - gufe=0.9.4
   - openfe=0.13.0
+  - openmmforcefields>=0.12.0
   - requests
   - click
   - pydantic<2.0

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -55,7 +55,7 @@ dependencies:
   # needed for openfe-benchmark tests
   - lomap2>=2.1.0
   - openmmtools
-  - openmmforcefields
+  - openmmforcefields>=0.12.0
 
   - pip:
     - async_lru


### PR DESCRIPTION
Even though 0.12.0 is currently the latest version of `openmmforcefields`, building the env without forcing it appears to get 0.11.2 at the moment.
