### PR TITLE
Fixing broken CI due to lomap import failures

### DIFF
--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -53,7 +53,7 @@ dependencies:
   - moto
 
   # needed for openfe-benchmark tests
-  - lomap2>=2.1.0
+  - lomap2>=3.0
   - openmmtools
   - openmmforcefields>=0.12.0
 


### PR DESCRIPTION
Attempt to force lomap2 > 3.0.
