### PR TITLE
Make test env use latest release of openfe and gufe instead of `main`

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -29,8 +29,8 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-    env:
-      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+    #env:
+    #  OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
       - uses: actions/checkout@v2
@@ -44,13 +44,13 @@ jobs:
             environment-file: devtools/conda-envs/test.yml
             activate-environment: alchemiscale-test
 
-      - name: Decrypt OpenEye license
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        env:
-          OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
-        run: |
-          echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
-          python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+      #- name: Decrypt OpenEye license
+      #  if: ${{ !github.event.pull_request.head.repo.fork }}
+      #  env:
+      #    OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      #  run: |
+      #    echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+      #    python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
 
       - name: "Install"
         run: python -m pip install --no-deps -e .

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -29,8 +29,6 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-    #env:
-    #  OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
       - uses: actions/checkout@v2
@@ -44,13 +42,6 @@ jobs:
             environment-file: devtools/conda-envs/test.yml
             activate-environment: alchemiscale-test
 
-      #- name: Decrypt OpenEye license
-      #  if: ${{ !github.event.pull_request.head.repo.fork }}
-      #  env:
-      #    OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
-      #  run: |
-      #    echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
-      #    python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
 
       - name: "Install"
         run: python -m pip install --no-deps -e .

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -6,18 +6,12 @@ channels:
 dependencies:
   - pip
 
-  # gufe dependencies
-  - numpy<1.24  # https://github.com/numba/numba/issues/8615#issuecomment-1360792615
-  - networkx
-  - rdkit
-  - pydantic<2.0
-  - openff-toolkit
-  - openff-units >=0.2.0
-  - openff-models >=0.0.4
-  - openeye-toolkits
-  - typing-extensions
-
   # alchemiscale dependencies
+  - gufe
+  - openfe
+  - openmmforcefields>=0.12.0
+  - pydantic<2.0
+
   ## state store
   - neo4j-python-driver
   - py2neo
@@ -52,16 +46,7 @@ dependencies:
   - coverage
   - moto
 
-  # needed for openfe-benchmark tests
-  - lomap2>=3.0
-  - openmmtools
-  - openmmforcefields>=0.12.0
-
   - pip:
     - async_lru
     - git+https://github.com/dotsdl/grolt@relax-cryptography # neo4j test server deployment
-    - git+https://github.com/OpenFreeEnergy/gufe
-    - git+https://github.com/OpenFreeEnergy/openfe
     - git+https://github.com/OpenFreeEnergy/openfe-benchmarks
-    #- git+https://github.com/mikemhenry/openff-models.git@support_nested_models
-    #- git+https://github.com/openforcefield/protein-ligand-benchmark

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -2,7 +2,6 @@ name: alchemiscale-test
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
-  - openeye
 dependencies:
   - pip
 

--- a/devtools/conda-envs/test.yml
+++ b/devtools/conda-envs/test.yml
@@ -6,8 +6,8 @@ dependencies:
   - pip
 
   # alchemiscale dependencies
-  - gufe
-  - openfe
+  - gufe>=0.9.5
+  - openfe>=0.14.0
   - openmmforcefields>=0.12.0
   - pydantic<2.0
 


### PR DESCRIPTION
Now that `openfe` and `gufe` are operating at regular release cadences, I think it makes sense for us to perform testing against the latest releases of these on `conda-forge` instead of testing against the `main` branches of them. In particular, this saves us the need of having to manually track their dependencies, such as the recently added `kartograf` dependency in `openfe`.

I think this is generally a safe move, since we only ever deploy production envs with releases of these packages too (pinned to specific releases). The CI/test env still operates as a canary of upstream changes, but on a delay dependent on upstream releases compared to current state.
