### PR TITLE
Remove `return_gufe` kwarg from `AlchemiscaleClient.query_networks`

### DIFF
--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -135,25 +135,25 @@ def create_network(
 def query_networks(
     *,
     name: str = None,
-    return_gufe: bool = False,
     scope: Scope = Depends(scope_params),
     n4js: Neo4jStore = Depends(get_n4js_depends),
     token: TokenData = Depends(get_token_data_depends),
 ):
     # Intersect query scopes with accessible scopes in the token
     query_scopes = validate_scopes_query(scope, token)
-    networks_handler = QueryGUFEHandler(return_gufe)
 
     # query each scope
     # loop might be removable in the future with a Union like operator on scopes
+    results = []
     for single_query_scope in query_scopes:
-        networks_handler.update_results(
+        results.extend(
             n4js.query_networks(
-                name=name, scope=single_query_scope, return_gufe=return_gufe
+                name=name,
+                scope=single_query_scope,
             )
         )
 
-    return networks_handler.format_return()
+    return [str(sk) for sk in results]
 
 
 @router.get("/transformations")

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -136,7 +136,6 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         self,
         name: Optional[str] = None,
         scope: Optional[Scope] = None,
-        return_gufe=False,
     ) -> Union[List[ScopedKey], Dict[ScopedKey, AlchemicalNetwork]]:
         """Query for AlchemicalNetworks, optionally by name or Scope.
 
@@ -145,19 +144,13 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         to.
 
         """
-        if return_gufe:
-            networks = {}
-        else:
-            networks = []
+        networks = []
 
         if scope is None:
             scope = Scope()
 
-        params = dict(name=name, return_gufe=return_gufe, **scope.dict())
-        if return_gufe:
-            networks.update(self._query_resource("/networks", params=params))
-        else:
-            networks.extend(self._query_resource("/networks", params=params))
+        params = dict(name=name, **scope.dict())
+        networks.extend(self._query_resource("/networks", params=params))
 
         return networks
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -136,7 +136,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         self,
         name: Optional[str] = None,
         scope: Optional[Scope] = None,
-    ) -> Union[List[ScopedKey], Dict[ScopedKey, AlchemicalNetwork]]:
+    ) -> List[ScopedKey]:
         """Query for AlchemicalNetworks, optionally by name or Scope.
 
         Calling this method with no query arguments will return ScopedKeys for
@@ -144,15 +144,12 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         to.
 
         """
-        networks = []
-
         if scope is None:
             scope = Scope()
 
         params = dict(name=name, **scope.dict())
-        networks.extend(self._query_resource("/networks", params=params))
 
-        return networks
+        return self._query_resource("/networks", params=params)
 
     def query_transformations(
         self,


### PR DESCRIPTION
Fixes #142 

This PR removes the `return_gufe` kwarg from the `AlchemiscaleClient.query_networks` method.
As it was not a tested feature before, not tests needed to be changed.

Edit: it also doesn't appear to be mentioned in the current docs.