### PR TITLE
Add `weight` kwarg to `AlchemiscaleClient.action_tasks` method

### DIFF
--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -490,22 +490,32 @@ def action_tasks(
     network_scoped_key,
     *,
     tasks: List[ScopedKey] = Body(embed=True),
-    weight: float = Body(embed=True),
+    weight: Optional[Union[float, List[float]]] = Body(None, embed=True),
     n4js: Neo4jStore = Depends(get_n4js_depends),
     token: TokenData = Depends(get_token_data_depends),
 ) -> List[Union[str, None]]:
     sk = ScopedKey.from_str(network_scoped_key)
     validate_scopes(sk.scope, token)
 
-    if not 0 <= weight <= 1:
-        raise HTTPException(
-            status_code=status.HTTPS_400_BAD_REQUEST,
-            detail=f"weight must between 0.0 and 1.0 (inclusive), the "
-            "provided weight was: {weight}",
-        )
-
     taskhub_sk = n4js.get_taskhub(sk)
-    actioned_sks = n4js.action_tasks(tasks, taskhub_sk, weight=weight)
+    actioned_sks = n4js.action_tasks(tasks, taskhub_sk)
+
+    try:
+        if isinstance(weight, float):
+            n4js.set_task_weights(tasks, taskhub_sk, weight)
+        elif isinstance(weight, list):
+            if len(weight) != len(tasks):
+                detail = "weight (when in a list) must have the same length as tasks"
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=detail,
+                )
+
+            n4js.set_task_weights(
+                {task: weight for task, weight in zip(tasks, weight)}, taskhub_sk, None
+            )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return [str(sk) if sk is not None else None for sk in actioned_sks]
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -622,7 +622,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         return status_counts
 
     def action_tasks(
-        self, tasks: List[ScopedKey], network: ScopedKey
+        self, tasks: List[ScopedKey], network: ScopedKey, weight: float = 0.5
     ) -> List[Optional[ScopedKey]]:
         """Action Tasks for execution via the given AlchemicalNetwork's
         TaskHub.
@@ -639,6 +639,10 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         network
             The AlchemicalNetwork ScopedKey to action the Tasks for.
             The Tasks will be added to the network's associated TaskHub.
+        weight
+            Task weight to be applied to all :class:``Task``s in an
+            :class:``AlchemicalNetwork``. Only values between 0 and 1 are
+            valid. The default weight is 0.5.
 
         Returns
         -------
@@ -648,7 +652,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             be returned in its place.
 
         """
-        data = dict(tasks=[t.dict() for t in tasks])
+        data = dict(tasks=[t.dict() for t in tasks], weight=weight)
         actioned_sks = self._post_resource(f"/networks/{network}/tasks/action", data)
 
         return [ScopedKey.from_str(i) if i is not None else None for i in actioned_sks]

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -622,7 +622,10 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         return status_counts
 
     def action_tasks(
-        self, tasks: List[ScopedKey], network: ScopedKey, weight: float = 0.5
+        self,
+        tasks: List[ScopedKey],
+        network: ScopedKey,
+        weight: Optional[Union[float, List[float]]] = None,
     ) -> List[Optional[ScopedKey]]:
         """Action Tasks for execution via the given AlchemicalNetwork's
         TaskHub.
@@ -640,9 +643,15 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             The AlchemicalNetwork ScopedKey to action the Tasks for.
             The Tasks will be added to the network's associated TaskHub.
         weight
-            Task weight to be applied to all :class:``Task``s in an
-            :class:``AlchemicalNetwork``. Only values between 0 and 1 are
-            valid. The default weight is 0.5.
+            Task weight to be applied to all :class:`Task`s in
+            an :class:`AlchemicalNetwork`. Only values between 0 and 1 are valid
+            weights. Weights can also be provided as a list of floats with the
+            same length as ``tasks``.
+
+            Setting ``weight`` to ``None`` will apply the default weight of 0.5
+            to newly actioned tasks, while leaving the weights of any previously
+            actioned tasks unchanged. Setting ``weight`` to anything other than
+            ``None`` can change the weights of previously actioned tasks.
 
         Returns
         -------

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -84,6 +84,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         network: AlchemicalNetwork,
         scope: Scope,
         compress: Union[bool, int] = True,
+        visualize: bool = True,
     ) -> ScopedKey:
         """Submit an AlchemicalNetwork to a specific Scope.
 
@@ -105,6 +106,8 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             Use an integer between 0 and 9 for finer control over
             the degree of compression; 0 means no compression, 9 means max
             compression. ``True`` is synonymous with level 5 compression.
+        visualize
+            If ``True``, show submission progress indicator.
 
         Returns
         -------
@@ -119,16 +122,25 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
         validate_network_nonself(network)
 
-        from rich.progress import Progress
-
         sk = self.get_scoped_key(network, scope)
-        with Progress(*self._rich_waiting_columns(), transient=False) as progress:
-            task = progress.add_task(f"Submitting [bold]'{sk}'[/bold]...", total=None)
 
+        def post():
             data = dict(network=network.to_dict(), scope=scope.dict())
-            scoped_key = self._post_resource("/networks", data, compress=compress)
-            progress.start_task(task)
-            progress.update(task, total=1, completed=1)
+            return self._post_resource("/networks", data, compress=compress)
+
+        if visualize:
+            from rich.progress import Progress
+
+            with Progress(*self._rich_waiting_columns(), transient=False) as progress:
+                task = progress.add_task(
+                    f"Submitting [bold]'{sk}'[/bold]...", total=None
+                )
+
+                scoped_key = post()
+                progress.start_task(task)
+                progress.update(task, total=1, completed=1)
+        else:
+            scoped_key = post()
 
         return ScopedKey.from_dict(scoped_key)
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -621,8 +621,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         TaskHub.
 
         A Task cannot be actioned:
-            - to an AlchemicalNetwork in a different Scope.
-            - if it extends another Task that is not complete.
+            - to an AlchemicalNetwork in a different Scope
             - if it has any status other than 'waiting', 'running', or 'error'
 
         Parameters
@@ -633,22 +632,22 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             The AlchemicalNetwork ScopedKey to action the Tasks for.
             The Tasks will be added to the network's associated TaskHub.
         weight
-            Task weight to be applied to all :class:`Task`s in
-            an :class:`AlchemicalNetwork`. Only values between 0 and 1 are valid
-            weights. Weights can also be provided as a list of floats with the
-            same length as ``tasks``.
+            Weight to be applied to the actioned Tasks. Only values between 0
+            and 1 are valid weights. Weights can also be provided as a list of
+            floats with the same length as `tasks`.
 
-            Setting ``weight`` to ``None`` will apply the default weight of 0.5
-            to newly actioned tasks, while leaving the weights of any previously
-            actioned tasks unchanged. Setting ``weight`` to anything other than
-            ``None`` can change the weights of previously actioned tasks.
+            Setting `weight` to ``None`` will apply the default weight of 0.5
+            to newly actioned Tasks, while leaving the weights of any previously
+            actioned Tasks unchanged. Setting `weight` to anything other than
+            ``None`` will change the weights of previously actioned Tasks
+            included in `tasks`.
 
         Returns
         -------
         List[Optional[ScopedKey]]
             ScopedKeys for Tasks actioned, in the same order as given as
-            `tasks` on input. If a Task couldn't be actioned, then ``None`` will
-            be returned in its place.
+            `tasks` on input. If a Task couldn't be actioned, then ``None``
+            will be returned in its place.
 
         """
         data = dict(tasks=[t.dict() for t in tasks], weight=weight)

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1067,7 +1067,6 @@ class Neo4jStore(AlchemiscaleStateStore):
         self,
         tasks: List[ScopedKey],
         taskhub: ScopedKey,
-        weight: float = 0.5,
     ) -> List[Union[ScopedKey, None]]:
         """Add Tasks to the TaskHub for a given AlchemicalNetwork.
 
@@ -1098,7 +1097,7 @@ class Neo4jStore(AlchemiscaleStateStore):
                   AND task.status IN ['waiting', 'running', 'error']
 
                 // create the connection
-                CREATE (th)-[ar:ACTIONS {{weight: {weight}}}]->(task)
+                CREATE (th)-[ar:ACTIONS {{weight: 0.5}}]->(task)
 
                 // set the task property to the scoped key of the Task
                 // this is a convenience for when we have to loop over relationships in Python
@@ -1164,6 +1163,9 @@ class Neo4jStore(AlchemiscaleStateStore):
                         "Cannot set `weight` to a scalar if `tasks` is a dict"
                     )
 
+                if not all([0 <= weight <= 1 for weight in tasks.values()]):
+                    raise ValueError("weights must be between 0 and 1 (inclusive)")
+
                 for t, w in tasks.items():
                     q = f"""
                     MATCH (th:TaskHub {{_scoped_key: '{taskhub}'}})-[ar:ACTIONS]->(task:Task {{_scoped_key: '{t}'}})
@@ -1177,6 +1179,9 @@ class Neo4jStore(AlchemiscaleStateStore):
                     raise ValueError(
                         "Must set `weight` to a scalar if `tasks` is a list"
                     )
+
+                if not 0 <= weight <= 1:
+                    raise ValueError("weight must be between 0 and 1 (inclusive)")
 
                 for t in tasks:
                     q = f"""

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1067,6 +1067,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         self,
         tasks: List[ScopedKey],
         taskhub: ScopedKey,
+        weight: float = 0.5,
     ) -> List[Union[ScopedKey, None]]:
         """Add Tasks to the TaskHub for a given AlchemicalNetwork.
 
@@ -1097,7 +1098,7 @@ class Neo4jStore(AlchemiscaleStateStore):
                   AND task.status IN ['waiting', 'running', 'error']
 
                 // create the connection
-                CREATE (th)-[ar:ACTIONS {{weight: 1.0}}]->(task)
+                CREATE (th)-[ar:ACTIONS {{weight: {weight}}}]->(task)
 
                 // set the task property to the scoped key of the Task
                 // this is a convenience for when we have to loop over relationships in Python

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -739,10 +739,18 @@ class TestClient:
         # base case
         assert [0.5, 0.5, 0.5] == n4js.get_task_weights(task_sks, th_sk)
 
-        new_weights = [1.0, 1.0, 1.0]
+        new_weights = [1.0, 0.7, 0.4]
         user_client.action_tasks(task_sks, network_sk, new_weights)
 
         assert new_weights == n4js.get_task_weights(task_sks, th_sk)
+
+        # action a couple more tasks along with existing ones, then check weights as expected
+        new_task_sks = user_client.create_tasks(transformation_sk, count=2)
+        user_client.action_tasks(task_sks + new_task_sks, network_sk)
+
+        assert new_weights + [0.5] * 2 == n4js.get_task_weights(
+            task_sks + new_task_sks, th_sk
+        )
 
     def test_cancel_tasks(
         self,

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -918,12 +918,12 @@ class TestNeo4jStore(TestStateStore):
 
         # weights should all be the default 1.0
         weights = n4js.get_task_weights(task_sks, taskhub_sk)
-        assert all([w == 1.0 for w in weights])
+        assert all([w == 0.5 for w in weights])
 
         # set weights on the tasks to be all 10
-        n4js.set_task_weights(task_sks, taskhub_sk, weight=10)
+        n4js.set_task_weights(task_sks, taskhub_sk, weight=1.0)
         weights = n4js.get_task_weights(task_sks, taskhub_sk)
-        assert all([w == 10 for w in weights])
+        assert all([w == 1.0 for w in weights])
 
     def test_cancel_task(self, n4js, network_tyk2, scope_test):
         an = network_tyk2

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -916,11 +916,11 @@ class TestNeo4jStore(TestStateStore):
         task_sks = [n4js.create_task(transformation_sk) for i in range(10)]
         n4js.action_tasks(task_sks, taskhub_sk)
 
-        # weights should all be the default 1.0
+        # weights should all be the default 0.5
         weights = n4js.get_task_weights(task_sks, taskhub_sk)
         assert all([w == 0.5 for w in weights])
 
-        # set weights on the tasks to be all 10
+        # set weights on the tasks to be all 1.0
         n4js.set_task_weights(task_sks, taskhub_sk, weight=1.0)
         weights = n4js.get_task_weights(task_sks, taskhub_sk)
         assert all([w == 1.0 for w in weights])
@@ -1233,8 +1233,8 @@ class TestNeo4jStore(TestStateStore):
         # set weights on the tasks to be all 0, disabling them
         n4js.set_task_weights(task_sks, taskhub_sk, weight=0)
 
-        # set the weight of the first task to be 10
-        weight_dict = {task_sks[0]: 10}
+        # set the weight of the first task to be 1
+        weight_dict = {task_sks[0]: 1.0}
         n4js.set_task_weights(weight_dict, taskhub_sk)
 
         csid = ComputeServiceID("the best task handler")


### PR DESCRIPTION
In this PR, the kwarg `weight` has been added to the `AlchemiScaleClient.action_tasks` method, where its value is added to the data payload. Validation of the weight (restricted to be between 0 and 1, see #208 ) is handled at the API layer. The `Neo4jStore` also now has a `weight` kwarg that defaults to 0.5 (note that the previous weight was 1 and was hard coded).

fixes #202 