### PR TITLE
Add `get_network_actioned_tasks` and `get_task_actioned_networks` to `AlchemicaleClient`

### DIFF
--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -514,6 +514,19 @@ def get_network_actioned_tasks(
         return [str(task) for task in tasks]
 
 
+@router.get("/tasks/{task_sk}/networks/actioned")
+def get_task_actioned_networks(
+    task_sk,
+    *,
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    token: TokenData = Depends(get_token_data_depends),
+) -> List[str]:
+    task_sk = ScopedKey.from_str(task_sk)
+    validate_scopes(task_sk.scope, token)
+    networks = n4js.get_task_actioned_networks(task_sk)
+    return [str(n) for n in networks]
+
+
 @router.post("/networks/{network_scoped_key}/tasks/action")
 def action_tasks(
     network_scoped_key,

--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -514,15 +514,16 @@ def get_network_actioned_tasks(
         return [str(task) for task in tasks]
 
 
-@router.get("/tasks/{task_sk}/networks/actioned")
+@router.get("/tasks/{task_scoped_key}/networks/actioned")
 def get_task_actioned_networks(
-    task_sk,
+    task_scoped_key,
     *,
     n4js: Neo4jStore = Depends(get_n4js_depends),
     token: TokenData = Depends(get_token_data_depends),
 ) -> List[str]:
-    task_sk = ScopedKey.from_str(task_sk)
+    task_sk = ScopedKey.from_str(task_scoped_key)
     validate_scopes(task_sk.scope, token)
+
     networks = n4js.get_task_actioned_networks(task_sk)
     return [str(n) for n in networks]
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -621,17 +621,17 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         Parameters
         ----------
         network
-            ScopedKey for an AlchemicalNetwork.
+            The ScopedKey for the AlchemicalNetwork to get actioned Tasks for.
         task_weights
-            If ``True``, return a Dict whose keys and values are the Task
-            ScopedKeys and the Task weight, respectively.
+            If ``True``, return a dict with Task ScopedKeys as keys, Task
+            weights as values.
 
         Returns
         -------
         tasks
-            A List of Task ScopedKeys. If ``task_weights`` is ``True``, then
-            the returned type is a Dict whose keys and values are the
-            Task ScopedKeys and the Task weight, respectively.
+            A list of Task ScopedKeys. If ``task_weights`` is ``True``, then
+            the returned type is a dict with Task ScopedKeys as keys, Task
+            weights as values.
         """
         data = {"get_weights": task_weights}
         results = self._post_resource(f"/networks/{network}/tasks/actioned", data)
@@ -642,17 +642,17 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             return [ScopedKey.from_str(t) for t in results]
 
     def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
-        """Return all AlchemicalNetworks associated with a Task.
+        """Return all AlchemicalNetworks the given Task is actioned on.
 
         Parameters
         ----------
         task
-            ScopedKey of a task which may or may
+            The ScopedKey for the Task to get actioned AlchemicalNetworks for.
 
         Returns
         -------
         networks
-            List of networks which action the provided Task.
+            A list of AlchemicalNetwork ScopedKeys which action the given Task.
         """
         networks = self._get_resource(f"/tasks/{task}/networks/actioned")
         return [ScopedKey.from_str(n) for n in networks]

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -641,20 +641,30 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         else:
             return [ScopedKey.from_str(t) for t in results]
 
-    def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
+    def get_task_actioned_networks(
+        self, task: ScopedKey, task_weights: bool = False
+    ) -> Union[Dict[ScopedKey, float], List[ScopedKey]]:
         """Return all AlchemicalNetworks the given Task is actioned on.
 
         Parameters
         ----------
         task
             The ScopedKey for the Task to get actioned AlchemicalNetworks for.
+        task_weights
+            If ``True``, return a dictionary whose keys are the ScopedKeys
+            of the AlchemicalNetworks that the ``Task`` ACTIONS and the
+            values are the weights of the ACTIONS relationship.
 
         Returns
         -------
         networks
             A list of AlchemicalNetwork ScopedKeys which action the given Task.
+            If task_weights is ``True``, a dictionary is returned.
         """
-        networks = self._get_resource(f"/tasks/{task}/networks/actioned")
+        data = dict(task_weights=task_weights)
+        networks = self._post_resource(f"/tasks/{task}/networks/actioned", data)
+        if task_weights:
+            return {ScopedKey.from_str(n): weight for n, weight in networks.items()}
         return [ScopedKey.from_str(n) for n in networks]
 
     def action_tasks(

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -668,9 +668,9 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         Returns
         -------
         tasks
-            A list of Task ScopedKeys. If ``task_weights`` is ``True``, then
-            the returned type is a dict with Task ScopedKeys as keys, Task
-            weights as values.
+            A list of Task ScopedKeys actioned on the given AlchemicalNetwork.
+            If ``task_weights`` is ``True``, a dict is returned with Task
+            ScopedKeys as keys, Task weights as values.
         """
         data = dict(task_weights=task_weights)
         tasks = self._post_resource(f"/networks/{network}/tasks/actioned", data)

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -611,6 +611,39 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
         return status_counts
 
+    def get_network_actioned_tasks(
+        self,
+        network: ScopedKey,
+        task_weights: bool = False,
+    ) -> Union[Dict[ScopedKey, float], List[ScopedKey]]:
+        """Return all networks given an actioned Task.
+
+        Parameters
+        ----------
+        network
+            ScopedKey for an AlchemicalNetwork.
+        task_weights
+            If ``True``, return a Dict whose keys and values are the Task
+            ScopedKeys and the Task weight, respectively.
+
+        Returns
+        -------
+        tasks
+            A List of Task ScopedKeys. If ``task_weights`` is ``True``, then
+            the returned type is a Dict whose keys and values are the
+            Task ScopedKeys and the Task weight, respectively.
+        """
+        data = {"get_weights": task_weights}
+        results = self._post_resource(f"/networks/{network}/tasks/actioned", data)
+
+        if task_weights:
+            return {ScopedKey.from_str(t): w for t, w in results.items()}
+        else:
+            return [ScopedKey.from_str(t) for t in results]
+
+    def get_task_actioned_networks(self, task: ScopedKey) -> List[Optional[ScopedKey]]:
+        raise NotImplementedError
+
     def action_tasks(
         self, tasks: List[ScopedKey], network: ScopedKey
     ) -> List[Optional[ScopedKey]]:

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -616,7 +616,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         network: ScopedKey,
         task_weights: bool = False,
     ) -> Union[Dict[ScopedKey, float], List[ScopedKey]]:
-        """Return all networks given an actioned Task.
+        """Return all actioned Tasks for a given AlchemicalNetwork.
 
         Parameters
         ----------
@@ -641,8 +641,21 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         else:
             return [ScopedKey.from_str(t) for t in results]
 
-    def get_task_actioned_networks(self, task: ScopedKey) -> List[Optional[ScopedKey]]:
-        raise NotImplementedError
+    def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
+        """Return all AlchemicalNetworks associated with a Task.
+
+        Parameters
+        ----------
+        task
+            ScopedKey of a task which may or may
+
+        Returns
+        -------
+        networks
+            List of networks which action the provided Task.
+        """
+        networks = self._get_resource(f"/tasks/{task}/networks/actioned")
+        return [ScopedKey.from_str(n) for n in networks]
 
     def action_tasks(
         self, tasks: List[ScopedKey], network: ScopedKey

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -677,7 +677,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
         if task_weights:
             return {ScopedKey.from_str(t): w for t, w in tasks.items()}
-        
+
         return [ScopedKey.from_str(t) for t in tasks]
 
     def get_task_actioned_networks(

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -663,7 +663,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             The ScopedKey for the AlchemicalNetwork to get actioned Tasks for.
         task_weights
             If ``True``, return a dict with Task ScopedKeys as keys, Task
-            weights as values.
+            weights on the AlchemicalNetwork as values.
 
         Returns
         -------
@@ -672,13 +672,13 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             the returned type is a dict with Task ScopedKeys as keys, Task
             weights as values.
         """
-        data = {"get_weights": task_weights}
-        results = self._post_resource(f"/networks/{network}/tasks/actioned", data)
+        data = dict(task_weights=task_weights)
+        tasks = self._post_resource(f"/networks/{network}/tasks/actioned", data)
 
         if task_weights:
-            return {ScopedKey.from_str(t): w for t, w in results.items()}
-        else:
-            return [ScopedKey.from_str(t) for t in results]
+            return {ScopedKey.from_str(t): w for t, w in tasks.items()}
+        
+        return [ScopedKey.from_str(t) for t in tasks]
 
     def get_task_actioned_networks(
         self, task: ScopedKey, task_weights: bool = False
@@ -690,20 +690,23 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         task
             The ScopedKey for the Task to get actioned AlchemicalNetworks for.
         task_weights
-            If ``True``, return a dictionary whose keys are the ScopedKeys
-            of the AlchemicalNetworks that the ``Task`` ACTIONS and the
-            values are the weights of the ACTIONS relationship.
+            If ``True``, return a dict with AlchemicalNetwork ScopedKeys as
+            keys, the given Task's weights on each AlchemicalNetwork as values.
 
         Returns
         -------
         networks
             A list of AlchemicalNetwork ScopedKeys which action the given Task.
-            If task_weights is ``True``, a dictionary is returned.
+            If task_weights is ``True``, a dict is returned with
+            AlchemicalNetwork ScopedKeys as keys, Task weights as values.
+
         """
         data = dict(task_weights=task_weights)
         networks = self._post_resource(f"/tasks/{task}/networks/actioned", data)
+
         if task_weights:
             return {ScopedKey.from_str(n): weight for n, weight in networks.items()}
+
         return [ScopedKey.from_str(n) for n in networks]
 
     def action_tasks(

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1067,17 +1067,17 @@ class Neo4jStore(AlchemiscaleStateStore):
         self,
         taskhub: ScopedKey,
     ) -> List[ScopedKey]:
-        """Get the tasks that a given TaskHub ACTIONS.
+        """Get the Tasks that a given TaskHub ACTIONS.
 
         Parameters
         ----------
         taskhub
-            The ScopedKey of the taskhub to query.
+            The ScopedKey of the TaskHub to query.
 
         Returns
         -------
         tasks
-            The Tasks that are actioned by the given TaskHub.
+            The Tasks that are actioned on the given TaskHub.
         """
 
         q = """
@@ -1091,18 +1091,20 @@ class Neo4jStore(AlchemiscaleStateStore):
         return [ScopedKey.from_str(record.get("t._scoped_key")) for record in results]
 
     def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
-        """Get all network scoped keys whose TaskHub actions a given Task.
+        """Get all AlchemicalNetwork ScopedKeys whose TaskHub ACTIONS a given Task.
 
         Parameters
         ----------
         task
-            ScopedKey of the Task for determining the networks.
+            The ScopedKey of the Task to obtain actioned AlchemicalNetworks
+            for.
 
         Returns
         -------
         networks
-            A list of network ScopedKeys whose TaskHub actions a given Task.
-            If no TaskHubs action the Task, then an empty List is returned.
+            A list of AlchemicalNetwork ScopedKeys whose TaskHub actions a
+            given Task. If no TaskHubs action the Task, then an empty list is
+            returned.
         """
         q = """
            MATCH (an:AlchemicalNetwork)<-[:PERFORMS]-(TaskHub)-[:ACTIONS]->(Task {_scoped_key: $scoped_key})

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1088,10 +1088,9 @@ class Neo4jStore(AlchemiscaleStateStore):
         with self.transaction() as tx:
             results = tx.run(q, th_sk=str(taskhub))
 
-        tasks = [ScopedKey.from_str(record.get("t._scoped_key")) for record in results]
-        return tasks
+        return [ScopedKey.from_str(record.get("t._scoped_key")) for record in results]
 
-    def get_task_actioned_networks(self, task: ScopedKey) -> Optional[List[ScopedKey]]:
+    def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
         """Get all network scoped keys whose TaskHub actions a given Task.
 
         Parameters
@@ -1103,7 +1102,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         -------
         networks
             A list of network ScopedKeys whose TaskHub actions a given Task.
-            If no TaskHubs action the Task, then None is returned.
+            If no TaskHubs action the Task, then an empty List is returned.
         """
         q = """
            MATCH (an:AlchemicalNetwork)<-[:PERFORMS]-(TaskHub)-[:ACTIONS]->(Task {_scoped_key: $scoped_key})
@@ -1116,6 +1115,7 @@ class Neo4jStore(AlchemiscaleStateStore):
         networks = [
             ScopedKey.from_str(record.get("an._scoped_key")) for record in results
         ]
+
         return networks
 
     def action_tasks(

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1069,7 +1069,7 @@ class Neo4jStore(AlchemiscaleStateStore):
     def get_taskhub_actioned_tasks(
         self,
         taskhub: ScopedKey,
-    ) -> List[ScopedKey]:
+    ) -> Dict[ScopedKey, float]:
         """Get the Tasks that a given TaskHub ACTIONS.
 
         Parameters
@@ -1080,20 +1080,23 @@ class Neo4jStore(AlchemiscaleStateStore):
         Returns
         -------
         tasks
-            The Tasks that are actioned on the given TaskHub.
+            A dict with Task ScopedKeys that are actioned on the given TaskHub
+            as keys, Task weights as values.
         """
 
         q = """
-           MATCH (th: TaskHub {_scoped_key: $th_sk})-[:ACTIONS]->(t:Task)
-           RETURN t._scoped_key
+           MATCH (th: TaskHub {_scoped_key: $th_sk})-[a:ACTIONS]->(t:Task)
+           RETURN t._scoped_key, a.weight
         """
 
         with self.transaction() as tx:
             results = tx.run(q, th_sk=str(taskhub))
 
-        return [ScopedKey.from_str(record.get("t._scoped_key")) for record in results]
+        return {
+            ScopedKey.from_str(record.get("t._scoped_key")): record.get("a.weight") 
+            for record in results}
 
-    def get_task_actioned_networks(self, task: ScopedKey) -> List[ScopedKey]:
+    def get_task_actioned_networks(self, task: ScopedKey) -> Dict[ScopedKey, float]:
         """Get all AlchemicalNetwork ScopedKeys whose TaskHub ACTIONS a given Task.
 
         Parameters
@@ -1105,23 +1108,21 @@ class Neo4jStore(AlchemiscaleStateStore):
         Returns
         -------
         networks
-            A list of AlchemicalNetwork ScopedKeys whose TaskHub actions a
-            given Task. If no TaskHubs action the Task, then an empty list is
-            returned.
+            A dict with AlchemicalNetwork ScopedKeys whose TaskHub actions a
+            given Task as keys, Task weights as values.
         """
+
         q = """
-           MATCH (an:AlchemicalNetwork)<-[:PERFORMS]-(TaskHub)-[:ACTIONS]->(Task {_scoped_key: $scoped_key})
-           RETURN an._scoped_key
+           MATCH (an:AlchemicalNetwork)<-[:PERFORMS]-(TaskHub)-[a:ACTIONS]->(Task {_scoped_key: $scoped_key})
+           RETURN an._scoped_key, a.weight
         """
 
         with self.transaction() as tx:
             results = tx.run(q, scoped_key=str(task))
 
-        networks = [
-            ScopedKey.from_str(record.get("an._scoped_key")) for record in results
-        ]
-
-        return networks
+        return {
+            ScopedKey.from_str(record.get("an._scoped_key")): record.get("a.weight") 
+            for record in results}
 
     def get_taskhub_weight(self, network: ScopedKey) -> float:
         """Get the weight for the TaskHub associated with the given

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1093,8 +1093,9 @@ class Neo4jStore(AlchemiscaleStateStore):
             results = tx.run(q, th_sk=str(taskhub))
 
         return {
-            ScopedKey.from_str(record.get("t._scoped_key")): record.get("a.weight") 
-            for record in results}
+            ScopedKey.from_str(record.get("t._scoped_key")): record.get("a.weight")
+            for record in results
+        }
 
     def get_task_actioned_networks(self, task: ScopedKey) -> Dict[ScopedKey, float]:
         """Get all AlchemicalNetwork ScopedKeys whose TaskHub ACTIONS a given Task.
@@ -1121,8 +1122,9 @@ class Neo4jStore(AlchemiscaleStateStore):
             results = tx.run(q, scoped_key=str(task))
 
         return {
-            ScopedKey.from_str(record.get("an._scoped_key")): record.get("a.weight") 
-            for record in results}
+            ScopedKey.from_str(record.get("an._scoped_key")): record.get("a.weight")
+            for record in results
+        }
 
     def get_taskhub_weight(self, network: ScopedKey) -> float:
         """Get the weight for the TaskHub associated with the given

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -636,8 +636,10 @@ class TestClient:
         if actioned_tasks:
             for network in networks:
                 user_client.action_tasks(task_sks, network)
-
-        results = user_client.get_task_actioned_networks(task_sks[0])
+        # without requesting weights, default
+        results = user_client.get_task_actioned_networks(
+            task_sks[0], task_weights=False
+        )
 
         # no promise keys will be in order
         results.sort()
@@ -648,6 +650,21 @@ class TestClient:
             assert results == networks
         else:
             assert results == []
+
+        # requesting weights
+        results = user_client.get_task_actioned_networks(task_sks[0], task_weights=True)
+
+        _networks = list(results.keys())
+        # networks has already been sorted above
+        _networks.sort()
+
+        if actioned_tasks:
+            assert len(results) == 2
+            assert _networks == networks
+            assert list(results.values()) == [1.0, 1.0]
+        else:
+            assert len(results) == 0
+            assert _networks == []
 
     def test_action_tasks(
         self,

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -649,7 +649,7 @@ class TestClient:
         )
 
         if get_weights:
-            assert list(results.values()) == [1.0, 1.0]
+            assert list(results.values()) == [0.5, 0.5]
         else:
             assert results == task_sks[:2]
 
@@ -706,7 +706,7 @@ class TestClient:
         if actioned_tasks:
             assert len(results) == 2
             assert _networks == networks
-            assert list(results.values()) == [1.0, 1.0]
+            assert list(results.values()) == [0.5, 0.5]
         else:
             assert len(results) == 0
             assert _networks == []

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -571,6 +571,44 @@ class TestClient:
         stat = user_client.get_transformation_status(transformation_sk)
         assert stat == {"complete": 5}
 
+    @pytest.mark.parametrize(
+        "get_weights",
+        [
+            (True),
+            (False),
+        ],
+    )
+    def test_get_network_actioned_tasks(
+        self,
+        scope_test,
+        n4js_preloaded,
+        user_client,
+        network_tyk2,
+        get_weights,
+    ):
+        n4js = n4js_preloaded
+
+        an = network_tyk2
+        transformation = list(an.edges)[0]
+
+        network_sk = user_client.get_scoped_key(an, scope_test)
+        transformation_sk = user_client.get_scoped_key(transformation, scope_test)
+
+        task_sks = user_client.create_tasks(transformation_sk, count=3)
+        user_client.action_tasks(task_sks[:2], network_sk)
+
+        results = user_client.get_network_actioned_tasks(
+            network_sk, task_weights=get_weights
+        )
+
+        if get_weights:
+            assert list(results.values()) == [1.0, 1.0]
+        else:
+            assert results == task_sks[:2]
+
+    def test_get_task_actioned_networks(self):
+        raise NotImplementedError
+
     def test_action_tasks(
         self,
         scope_test,

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -799,6 +799,11 @@ class TestNeo4jStore(TestStateStore):
         transformation_sk = n4js.get_scoped_key(transformation, scope_test)
 
         task_sks = [n4js.create_task(transformation_sk) for i in range(5)]
+
+        # do not action the tasks yet; should get back nothing
+        actioned_tasks = n4js.get_taskhub_actioned_tasks(taskhub_sk)
+        assert actioned_tasks == {}
+
         # action 3 of 5 tasks
         n4js.action_tasks(task_sks[:3], taskhub_sk)
 
@@ -806,6 +811,9 @@ class TestNeo4jStore(TestStateStore):
 
         assert len(actioned_tasks) == 3
         assert all([task_i in task_sks for task_i in actioned_tasks])
+
+        # check that we get back expected weights
+        all([w == 0.5 for w in actioned_tasks.values()])
 
     def test_get_task_actioned_networks(
         self, n4js: Neo4jStore, network_tyk2, scope_test
@@ -824,6 +832,10 @@ class TestNeo4jStore(TestStateStore):
 
         task_sk = n4js.create_task(transformation_sk)
 
+        # do not action the task yet; should get back nothing
+        an_sks = n4js.get_task_actioned_networks(task_sk)
+        assert an_sks == {}
+
         n4js.action_tasks([task_sk], taskhub_sk_1)
         n4js.action_tasks([task_sk], taskhub_sk_2)
 
@@ -831,25 +843,8 @@ class TestNeo4jStore(TestStateStore):
 
         assert all([an_sk in an_sks for an_sk in [network_sk_1, network_sk_2]])
 
-    def test_get_task_actioned_networks_not_actioned(
-        self,
-        n4js,
-        network_tyk2,
-        scope_test,
-    ):
-        an = network_tyk2
-        network_sk = n4js.create_network(an, scope_test)
-        taskhub_sk = n4js.create_taskhub(network_sk)
-
-        transformation = list(an.edges)[0]
-        transformation_sk = n4js.get_scoped_key(transformation, scope_test)
-
-        task_sk = n4js.create_task(transformation_sk)
-
-        # do not action the task and try and get the network
-        an_sks = n4js.get_task_actioned_networks(task_sk)
-
-        assert an_sks == []
+        # check that we get back expected weights
+        all([w == 0.5 for w in an_sks.values()])
 
     def test_get_taskhub_weight(self, n4js: Neo4jStore, network_tyk2, scope_test):
         network_sk = n4js.create_network(network_tyk2, scope_test)

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -831,6 +831,26 @@ class TestNeo4jStore(TestStateStore):
 
         assert all([an_sk in an_sks for an_sk in [network_sk_1, network_sk_2]])
 
+    def test_get_task_actioned_networks_not_actioned(
+        self,
+        n4js,
+        network_tyk2,
+        scope_test,
+    ):
+        an = network_tyk2
+        network_sk = n4js.create_network(an, scope_test)
+        taskhub_sk = n4js.create_taskhub(network_sk)
+
+        transformation = list(an.edges)[0]
+        transformation_sk = n4js.get_scoped_key(transformation, scope_test)
+
+        task_sk = n4js.create_task(transformation_sk)
+
+        # do not action the task and try and get the network
+        an_sks = n4js.get_task_actioned_networks(task_sk)
+
+        assert an_sks == []
+
     def test_action_task(self, n4js: Neo4jStore, network_tyk2, scope_test):
         an = network_tyk2
         network_sk = n4js.create_network(an, scope_test)

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -789,6 +789,48 @@ class TestNeo4jStore(TestStateStore):
         assert len(tq_dict) == 2
         assert all([isinstance(i, TaskHub) for i in tq_dict.values()])
 
+    def test_get_taskhub_actioned_tasks(
+        self, n4js: Neo4jStore, network_tyk2, scope_test
+    ):
+        an = network_tyk2
+        network_sk = n4js.create_network(an, scope_test)
+        taskhub_sk: ScopedKey = n4js.create_taskhub(network_sk)
+        transformation = list(an.edges)[0]
+        transformation_sk = n4js.get_scoped_key(transformation, scope_test)
+
+        task_sks = [n4js.create_task(transformation_sk) for i in range(5)]
+        # action 3 of 5 tasks
+        n4js.action_tasks(task_sks[:3], taskhub_sk)
+
+        actioned_tasks = n4js.get_taskhub_actioned_tasks(taskhub_sk)
+
+        assert len(actioned_tasks) == 3
+        assert all([task_i in task_sks for task_i in actioned_tasks])
+
+    def test_get_task_actioned_networks(
+        self, n4js: Neo4jStore, network_tyk2, scope_test
+    ):
+        an_1 = network_tyk2
+        an_2 = network_tyk2.copy_with_replacements(name=an_1.name + "_2")
+
+        network_sk_1 = n4js.create_network(an_1, scope_test)
+        network_sk_2 = n4js.create_network(an_2, scope_test)
+
+        taskhub_sk_1 = n4js.create_taskhub(network_sk_1)
+        taskhub_sk_2 = n4js.create_taskhub(network_sk_2)
+
+        transformation = list(an_1.edges)[0]
+        transformation_sk = n4js.get_scoped_key(transformation, scope_test)
+
+        task_sk = n4js.create_task(transformation_sk)
+
+        n4js.action_tasks([task_sk], taskhub_sk_1)
+        n4js.action_tasks([task_sk], taskhub_sk_2)
+
+        an_sks = n4js.get_task_actioned_networks(task_sk)
+
+        assert all([an_sk in an_sks for an_sk in [network_sk_1, network_sk_2]])
+
     def test_action_task(self, n4js: Neo4jStore, network_tyk2, scope_test):
         an = network_tyk2
         network_sk = n4js.create_network(an, scope_test)


### PR DESCRIPTION
fixes #173

This PR implements methods at the `statestore`, `interface/api`, and `interface/client` levels to give users access to Tasks and `AlchemicalNetworks` based on their relationship with one another.  
