### PR TITLE
Optimization to `gufe_to_digraph` to avoid repeated traversals, calls to `GufeTokenizable.to_shallow_dict`

### DIFF
--- a/alchemiscale/utils.py
+++ b/alchemiscale/utils.py
@@ -87,7 +87,6 @@ def gufe_to_digraph(gufe_obj):
     shallow_dicts = {}
 
     def add_edges(o):
-
         # if we've made a shallow dict before, we've already added this one
         # and all its dependencies; return `None` to avoid going down the tree
         # again

--- a/alchemiscale/utils.py
+++ b/alchemiscale/utils.py
@@ -86,20 +86,8 @@ def gufe_to_digraph(gufe_obj):
     graph = nx.DiGraph()
     shallow_dicts = {}
 
-    def add_edges(o, sd):
-        # add the object node in case there aren't any connections
-        graph.add_node(o)
-        connections = gufe_objects_from_shallow_dict(sd)
+    def add_edges(o):
 
-        for c in connections:
-            graph.add_edge(o, c)
-
-    sd = gufe_obj.to_shallow_dict()
-    shallow_dicts[gufe_obj.key] = sd
-
-    add_edges(gufe_obj, sd)
-
-    def modifier(o):
         # if we've made a shallow dict before, we've already added this one
         # and all its dependencies; return `None` to avoid going down the tree
         # again
@@ -110,14 +98,20 @@ def gufe_to_digraph(gufe_obj):
         # if not, then we make the shallow dict only once, add it to our index,
         # add edges to dependencies, and return it so we continue down the tree
         sd = o.to_shallow_dict()
+
         shallow_dicts[o.key] = sd
 
-        add_edges(o, sd)
+        # add the object node in case there aren't any connections
+        graph.add_node(o)
+        connections = gufe_objects_from_shallow_dict(sd)
+
+        for c in connections:
+            graph.add_edge(o, c)
+
         return sd
 
-    _ = modify_dependencies(
-        gufe_obj.to_shallow_dict(), modifier, is_gufe_obj, mode="encode"
-    )
+    sd = add_edges(gufe_obj)
+    _ = modify_dependencies(sd, add_edges, is_gufe_obj, mode="encode")
 
     return graph
 


### PR DESCRIPTION
Builds on the solution to #216.

Added use of a `shallow_dicts` index to avoid potentially expensive repeated calls of `GufeTokenizable.to_shallow_dict`, such as for `ProteinComponent`s. Also used as our check if we've already processed the object being visited to avoid going down its dependency tree again, avoiding repeated traversals.

For an `AlchemicalNetwork` with ~1000 `ChemicalSystem`s and ~2000 `Transformation`s, this optimization reduces `gufe_to_digraph` execution time from **6min 31s** to **811ms**.
