### PR TITLE
Simplify `action_tasks`

### DIFF
--- a/alchemiscale/storage/cypher.py
+++ b/alchemiscale/storage/cypher.py
@@ -1,0 +1,21 @@
+from alchemiscale import ScopedKey
+from typing import List, Optional
+
+
+def cypher_list_from_scoped_keys(scoped_keys: List[Optional[ScopedKey]]) -> str:
+    """Generate a Cypher list structure from a list of ScopedKeys, ignoring NoneType entries.
+    Parameters
+    ----------
+    scoped_keys
+        List of ScopedKeys to generate the Cypher list
+    Returns
+    -------
+    str
+        Cypher list
+    """
+
+    data = []
+    for scoped_key in scoped_keys:
+        if scoped_key:
+            data.append('"' + str(scoped_key) + '"')
+    return "[" + ", ".join(data) + "]"

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1187,7 +1187,7 @@ class Neo4jStore(AlchemiscaleStateStore):
             // and where the task is either in 'waiting', 'running', or 'error' status
             WITH th, an, task
             WHERE NOT (th)-[:ACTIONS]->(task)
-              AND task.status IN ['waiting', 'running', 'error']
+              AND task.status IN ['{TaskStatusEnum.waiting.value}', '{TaskStatusEnum.running.value}', '{TaskStatusEnum.error.value}']
 
             // create the connection
             CREATE (th)-[ar:ACTIONS {{weight: 0.5}}]->(task)
@@ -1200,6 +1200,7 @@ class Neo4jStore(AlchemiscaleStateStore):
             """
             results = tx.run(q).to_eager_result()
 
+        # update our map with the results, leaving None for tasks that aren't found
         for task_record in results.records:
             sk = task_record["task"]["_scoped_key"]
             task_map[str(sk)] = ScopedKey.from_str(sk)


### PR DESCRIPTION
`action_tasks` previously issued queries for each task to be actioned. This PR reduces this to a single query using the `UNWIND` clause, while accounting for the potential order loss from the `UNWIND`. Local tests show equal to improved performance depending on the number of tasks actioned. For $n=1$ tasks, the performance remains unchanged (~0.3 s). For $n=10, 100, 1000$, however, the runtime is reduced by (very) roughly $50\\%$, $80\\%$, and $90\\%$, respectively. More concretely this comes out to around:

* $n=10$; $0.7$ s to  $0.4$ s
* $n=100$; $3$ s to $0.6$ s
* $n=1000$; $24$ s to $1.6$ s