### PR TITLE
Adding bulk task creation server side

### DIFF
--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -358,7 +358,7 @@ def create_tasks(
 
 
 @router.post("/bulk/transformations/tasks/create")
-def create_bulk_tasks(
+def create_transformations_tasks(
     *,
     transformations: List[str] = Body(embed=True),
     extends: Optional[List[Optional[str]]] = None,
@@ -379,8 +379,10 @@ def create_bulk_tasks(
             for extends_str in extends
         ]
 
-    # TODO: raise Bad Request for ValueErrors raised
-    task_sks = n4js.create_tasks(transformation_sks, extends)
+    try:
+        task_sks = n4js.create_tasks(transformation_sks, extends)
+    except ValueError as e:
+        raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return [str(sk) for sk in task_sks]
 

--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -353,11 +353,34 @@ def create_tasks(
     sk = ScopedKey.from_str(transformation_scoped_key)
     validate_scopes(sk.scope, token)
 
-    task_sks = []
-    for i in range(count):
-        task_sks.append(
-            n4js.create_task(transformation=sk, extends=extends, creator=token.entity)
-        )
+    task_sks = n4js.create_tasks([sk] * count, [extends] * count)
+    return [str(sk) for sk in task_sks]
+
+
+@router.post("/bulk/transformations/tasks/create")
+def create_bulk_tasks(
+    *,
+    transformations: List[str] = Body(embed=True),
+    extends: Optional[List[Optional[str]]] = None,
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    token: TokenData = Depends(get_token_data_depends),
+):
+    transformation_sks = [
+        ScopedKey.from_str(transformation_string)
+        for transformation_string in transformations
+    ]
+
+    for transformation_sk in transformation_sks:
+        validate_scopes(transformation_sk.scope, token)
+
+    if extends is not None:
+        extends = [
+            None if not extends_str else ScopedKey.from_str(extends_str)
+            for extends_str in extends
+        ]
+
+    # TODO: raise Bad Request for ValueErrors raised
+    task_sks = n4js.create_tasks(transformation_sks, extends)
 
     return [str(sk) for sk in task_sks]
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -474,6 +474,46 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         transformations: List[ScopedKey],
         extends: Optional[List[Optional[ScopedKey]]] = None,
     ) -> List[ScopedKey]:
+        """Create Tasks for multiple Transformations.
+
+        Unlike `create_tasks`, this method can create Tasks for many
+        Transformations. This method should be used instead of `create_tasks`
+        whenever creating Tasks for more than one unique Transformation since it
+        minimizes the number of API requests to the alchemiscale server.
+
+
+        Parameters
+        ----------
+        transformations
+            A list of ScopedKeys of Transformations to create Tasks for. The
+            same ScopedKey can be repeated to create multiple Tasks for the
+            same Transformation.
+        extends
+            A list of ScopedKeys for the Tasks to be extended. When not `None`,
+            `extends` must be a list of the same length as `transformations`. If
+            a transformation in `transformations` should not extend a Task, use
+            a `None` as a placeholder in the `extends` list.
+
+        Returns
+        -------
+        List[ScopedKey]
+            A list giving the ScopedKeys of the new Tasks created.
+
+        Examples
+        --------
+
+        Instead of looping over Transformations and calling `create_tasks`, make
+        one call to `create_transformations_tasks`.
+
+        >>> client.create_transformations_tasks([transformation_1_sk, transformation_2_sk])
+
+        The behavior of the `count` keyword argument from `create_tasks` can be
+        recreated by repeating the same transformation in the list while also
+        allowing the addition of other transformtions.
+
+        >>> client.create_transformations_tasks([transformation_1_sk] * 3 + [transformation_2_sk] * 2)
+
+        """
 
         data = dict(
             transformations=[str(transformation) for transformation in transformations],

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -469,7 +469,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         task_sks = self._post_resource(f"/transformations/{transformation}/tasks", data)
         return [ScopedKey.from_str(i) for i in task_sks]
 
-    def create_bulk_tasks(
+    def create_transformations_tasks(
         self,
         transformations: List[ScopedKey],
         extends: Optional[List[Optional[ScopedKey]]] = None,

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -469,6 +469,25 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         task_sks = self._post_resource(f"/transformations/{transformation}/tasks", data)
         return [ScopedKey.from_str(i) for i in task_sks]
 
+    def create_bulk_tasks(
+        self,
+        transformations: List[ScopedKey],
+        extends: Optional[List[Optional[ScopedKey]]] = None,
+    ) -> List[ScopedKey]:
+
+        data = dict(
+            transformations=[str(transformation) for transformation in transformations],
+            extends=(
+                None
+                if not extends
+                else [
+                    str(task_sk) if task_sk is not None else None for task_sk in extends
+                ]
+            ),
+        )
+        task_sks = self._post_resource("/bulk/transformations/tasks/create", data)
+        return [ScopedKey.from_str(i) for i in task_sks]
+
     def query_tasks(
         self,
         scope: Optional[Scope] = None,

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -481,7 +481,6 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         whenever creating Tasks for more than one unique Transformation since it
         minimizes the number of API requests to the alchemiscale server.
 
-
         Parameters
         ----------
         transformations

--- a/alchemiscale/storage/cypher.py
+++ b/alchemiscale/storage/cypher.py
@@ -1,0 +1,23 @@
+from alchemiscale import ScopedKey
+from typing import List, Optional
+
+
+def cypher_list_from_scoped_keys(scoped_keys: List[Optional[ScopedKey]]) -> str:
+    """Generate a Cypher list structure from a list of ScopedKeys, ignoring NoneType entries.
+
+    Parameters
+    ----------
+    scoped_keys
+        List of ScopedKeys to generate the Cypher list
+
+    Returns
+    -------
+    str
+        Cypher list
+    """
+
+    data = []
+    for scoped_key in scoped_keys:
+        if scoped_key:
+            data.append('"' + str(scoped_key) + '"')
+    return "[" + ", ".join(data) + "]"

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1626,6 +1626,8 @@ class Neo4jStore(AlchemiscaleStateStore):
 
         subgraph = Subgraph()
 
+        sks = []
+        # iterate over all allowed types, unpacking the transformations and extends subsets
         for node_type, (
             transformation_subset,
             extends_subset,
@@ -1646,16 +1648,6 @@ class Neo4jStore(AlchemiscaleStateStore):
             for record in results.records:
                 node = record_data_to_node(record["n"])
                 transformation_nodes[node["_scoped_key"]] = node
-
-            tasks = [
-                Task(
-                    creator=creator,
-                    extends=str(_extends) if _extends is not None else None,
-                )
-                for _extends in extends_subset
-            ]
-
-            sks = []
 
             for _transformation, _extends in zip(transformation_subset, extends_subset):
 

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1566,11 +1566,10 @@ class Neo4jStore(AlchemiscaleStateStore):
             status = node.get("status")
 
             if status in ("invalid", "deleted"):
-                # py2neo Node doesn't like the neo4j datetime object
-                # manually cast since we're raising anyways
-                # and the results are ephemeral
-                node["datetime_created"] = str(node["datetime_created"])
-                raise ValueError(f"Cannot extend a `deleted` or `invalid` Task: {node}")
+                invalid_task_scoped_key = node["_scoped_key"]
+                raise ValueError(
+                    f"Cannot extend a `deleted` or `invalid` Task: {invalid_task_scoped_key}"
+                )
 
             nodes[node["_scoped_key"]] = (node, transformation_sk)
 

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1581,21 +1581,20 @@ class Neo4jStore(AlchemiscaleStateStore):
         extends: Optional[List[Optional[ScopedKey]]] = None,
         creator: Optional[str] = None,
     ) -> List[ScopedKey]:
-        """Add a compute Task to a Transformation.
+        """Add compute Tasks to a provided Transformations.
 
-        Note: this creates a compute Task, but does not add it to any TaskHubs.
+        Note: this creates compute Tasks, but does not add them to any TaskHubs.
 
         Parameters
         ----------
-        transformation
-            The Transformation to compute.
-        scope
-            The scope the Transformation is in; ignored if `transformation` is a ScopedKey.
+        transformations
+            The Transformations to compute.
         extends
-            The ScopedKey of the Task to use as a starting point for this Task.
+            The ScopedKeys of the Tasks to use as a starting point for the Tasks.
             Will use the `ProtocolDAGResult` from the given Task as the
             `extends` input for the Task's eventual call to `Protocol.create`.
-
+        creator (optional)
+            The creator of the Tasks
         """
 
         allowed_types = [Transformation.__qualname__, NonTransformation.__qualname__]

--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -1544,7 +1544,7 @@ class Neo4jStore(AlchemiscaleStateStore):
 
     ## tasks
 
-    def validate_extends_tasks(self, task_list) -> Dict[str, Tuple[Node, str]]:
+    def _validate_extends_tasks(self, task_list) -> Dict[str, Tuple[Node, str]]:
 
         if not task_list:
             return {}
@@ -1633,7 +1633,7 @@ class Neo4jStore(AlchemiscaleStateStore):
             transformation_map[transformation.qualname][0].append(transformation)
             transformation_map[transformation.qualname][1].append(extends[i])
 
-        extends_nodes = self.validate_extends_tasks(
+        extends_nodes = self._validate_extends_tasks(
             [_extends for _extends in extends if _extends is not None]
         )
 
@@ -1687,7 +1687,7 @@ class Neo4jStore(AlchemiscaleStateStore):
 
                     if extends_transformation_sk != str(_transformation):
                         raise ValueError(
-                            f"{_extends} extends a transformation other than {_transformation}"
+                            f"{_extends} extends a Transformation other than {_transformation}"
                         )
 
                     subgraph |= Relationship.type("EXTENDS")(

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -10,6 +10,7 @@ import networkx as nx
 
 from alchemiscale.models import ScopedKey, Scope
 from alchemiscale.storage.models import TaskStatusEnum
+from alchemiscale.storage.cypher import cypher_list_from_scoped_keys
 from alchemiscale.interface import client
 from alchemiscale.utils import RegistryBackup
 from alchemiscale.tests.integration.interface.utils import (
@@ -362,6 +363,81 @@ class TestClient:
             n4js.get_transformation_tasks(sk, extends=task_sks[0])
         )
         assert set() == set(n4js.get_transformation_tasks(sk, extends=task_sks[1]))
+
+    def test_create_bulk_tasks(
+        self,
+        scope_test,
+        n4js_preloaded,
+        user_client: client.AlchemiscaleClient,
+        network_tyk2,
+    ):
+        n4js = n4js_preloaded
+
+        an = network_tyk2
+        transformations = list(an.edges)[:5]
+
+        transformation_sks = [
+            user_client.get_scoped_key(transformation, scope_test)
+            for transformation in transformations
+        ]
+
+        # create three copies tasks per transformation
+        task_sks = user_client.create_bulk_tasks(transformation_sks * 3)
+
+        all_tasks = set()
+        extends_list = []
+        for transformation_sk in transformation_sks:
+            transformation_tasks = n4js.get_transformation_tasks(transformation_sk)
+            # there should be three tasks for each transformation
+            assert len(transformation_tasks) == 3
+            all_tasks |= set(transformation_tasks)
+
+            # we will want to test extensions, hold on to some tasks
+            extends_list.append(transformation_tasks[0])
+
+        assert set(task_sks) == all_tasks
+
+        # create a new set of tasks
+        extends_tasks = user_client.create_bulk_tasks(
+            transformation_sks, extends=extends_list
+        )
+
+        # should still have 5
+        assert len(extends_tasks) == 5
+
+        # get all of the original tasks, given our extension tasks
+        q = f"""UNWIND {cypher_list_from_scoped_keys(extends_tasks)} AS e_task
+        MATCH (Task {{`_scoped_key`: e_task}})-[:EXTENDS]->(original_task:Task)
+        RETURN original_task._scoped_key AS original_task
+        """
+        results = n4js.execute_query(q)
+
+        assert len(results.records) == 5
+
+        # check that we extended the correct tasks
+        for record in results.records:
+            original = ScopedKey.from_str(record["original_task"])
+            assert original in extends_list
+
+        # make sure the first transformation_sk isn't extending an already existing task
+        extends_list[0] = None
+
+        # confirm we still have 5 entries
+        assert len(extends_list) == 5
+
+        extends_tasks = user_client.create_bulk_tasks(
+            transformation_sks, extends=extends_list
+        )
+
+        q = f"""UNWIND {cypher_list_from_scoped_keys(extends_tasks)} AS e_task
+        MATCH (Task {{`_scoped_key`: e_task}})-[:EXTENDS]->(original_task:Task)
+        RETURN original_task._scoped_key AS original_task
+        """
+        results = n4js.execute_query(q)
+
+        # we should only have 4 original tasks even though we
+        # created 5 new tasks
+        assert len(results.records) == 4 and len(extends_tasks) == 5
 
     def test_query_tasks(
         self,

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -364,7 +364,7 @@ class TestClient:
         )
         assert set() == set(n4js.get_transformation_tasks(sk, extends=task_sks[1]))
 
-    def test_create_bulk_tasks(
+    def test_create_transformations_tasks(
         self,
         scope_test,
         n4js_preloaded,
@@ -382,7 +382,7 @@ class TestClient:
         ]
 
         # create three copies tasks per transformation
-        task_sks = user_client.create_bulk_tasks(transformation_sks * 3)
+        task_sks = user_client.create_transformations_tasks(transformation_sks * 3)
 
         all_tasks = set()
         extends_list = []
@@ -398,7 +398,7 @@ class TestClient:
         assert set(task_sks) == all_tasks
 
         # create a new set of tasks
-        extends_tasks = user_client.create_bulk_tasks(
+        extends_tasks = user_client.create_transformations_tasks(
             transformation_sks, extends=extends_list
         )
 
@@ -415,9 +415,10 @@ class TestClient:
         assert len(results.records) == 5
 
         # check that we extended the correct tasks
-        for record in results.records:
-            original = ScopedKey.from_str(record["original_task"])
-            assert original in extends_list
+        originals = [
+            ScopedKey.from_str(record["original_task"]) for record in results.records
+        ]
+        assert set(originals) == set(extends_list)
 
         # make sure the first transformation_sk isn't extending an already existing task
         extends_list[0] = None
@@ -425,7 +426,7 @@ class TestClient:
         # confirm we still have 5 entries
         assert len(extends_list) == 5
 
-        extends_tasks = user_client.create_bulk_tasks(
+        extends_tasks = user_client.create_transformations_tasks(
             transformation_sks, extends=extends_list
         )
 

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -1159,7 +1159,8 @@ class TestNeo4jStore(TestStateStore):
         transformation_sk = n4js.get_scoped_key(transformation, scope_test)
 
         # create 10 tasks
-        task_sks = n4js.create_tasks([transformation_sk] * 10)
+        N = 10
+        task_sks = n4js.create_tasks([transformation_sk] * N)
 
         # shuffle the tasks; want to check that order of claiming is unrelated
         # to order created

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -519,8 +519,13 @@ class TestNeo4jStore(TestStateStore):
         for record in results.records:
             # n is a parent Task, m is a child Task
             n, m = record["n"], record["m"]
-            assert ScopedKey.from_str(n["_scoped_key"]) in task_sks
-            assert ScopedKey.from_str(m["_scoped_key"]) in child_task_sks
+
+            task_sk = ScopedKey.from_str(n["_scoped_key"])
+            assert task_sk in task_sks
+
+            child_task_sk = child_task_sks[task_sks.index(task_sk)]
+
+            assert ScopedKey.from_str(m["_scoped_key"]) == child_task_sk
 
     def test_create_task_extends_invalid_deleted(self, n4js, network_tyk2, scope_test):
         # add alchemical network, then try generating task


### PR DESCRIPTION
This PR introduces the `create_tasks` method to the `Neo4jStore`. It attempts to minimize the queries made to the database when creating and extending tasks. From local tests, the performance for $n=1$ task created is the same. When creating thousands of tasks, the runtime drops to about one fifth of its previous value (~23 s to 4 s).