### PR TITLE
Add more bulk methods to the Alchemiscale client

### DIFF
--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -198,34 +198,6 @@ def query_chemicalsystems(
     return [str(sk) for sk in results]
 
 
-@router.get("/networks/{network_scoped_key}/weight")
-def get_network_weight(
-    network_scoped_key,
-    *,
-    n4js: Neo4jStore = Depends(get_n4js_depends),
-    token: TokenData = Depends(get_token_data_depends),
-) -> float:
-    sk = ScopedKey.from_str(network_scoped_key)
-    validate_scopes(sk.scope, token)
-    return n4js.get_taskhub_weight([sk])[0]
-
-
-@router.post("/bulk/networks/weight/get")
-def get_networks_weight(
-    *,
-    networks: List[str] = Body(embed=True),
-    n4js: Neo4jStore = Depends(get_n4js_depends),
-    token: TokenData = Depends(get_token_data_depends),
-) -> List[float]:
-
-    network_sks = [ScopedKey.from_str(network_str) for network_str in networks]
-
-    for network_sk in network_sks:
-        validate_scopes(network_sk.scope, token)
-
-    return n4js.get_taskhub_weight(network_sks)
-
-
 @router.get("/networks/{network_scoped_key}/transformations")
 def get_network_transformations(
     network_scoped_key,
@@ -569,7 +541,6 @@ def get_networks_actioned_tasks(
                 {str(task_sk): weight for task_sk, weight in group.items()}
             )
         else:
-            print(group)
             return_data.append([str(task_sk) for task_sk in group])
 
     return return_data
@@ -627,6 +598,34 @@ def action_tasks(
         raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return [str(sk) if sk is not None else None for sk in actioned_sks]
+
+
+@router.get("/networks/{network_scoped_key}/weight")
+def get_network_weight(
+    network_scoped_key,
+    *,
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    token: TokenData = Depends(get_token_data_depends),
+) -> float:
+    sk = ScopedKey.from_str(network_scoped_key)
+    validate_scopes(sk.scope, token)
+    return n4js.get_taskhub_weight([sk])[0]
+
+
+@router.post("/bulk/networks/weight/get")
+def get_networks_weight(
+    *,
+    networks: List[str] = Body(embed=True),
+    n4js: Neo4jStore = Depends(get_n4js_depends),
+    token: TokenData = Depends(get_token_data_depends),
+) -> List[float]:
+
+    network_sks = [ScopedKey.from_str(network_str) for network_str in networks]
+
+    for network_sk in network_sks:
+        validate_scopes(network_sk.scope, token)
+
+    return n4js.get_taskhub_weight(network_sks)
 
 
 @router.post("/networks/{network_scoped_key}/weight")

--- a/alchemiscale/interface/api.py
+++ b/alchemiscale/interface/api.py
@@ -640,7 +640,8 @@ def set_network_weight(
     validate_scopes(sk.scope, token)
 
     try:
-        n4js.set_taskhub_weight([sk], weight)
+        network_sk = n4js.set_taskhub_weight([sk], weight)[0]
+        return str(network_sk) if network_sk else None
     except ValueError as e:
         raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail=str(e))
 
@@ -660,9 +661,10 @@ def set_networks_weight(
         validate_scopes(network.scope, token)
 
     try:
-        n4js.set_taskhub_weight(
+        network_sks = n4js.set_taskhub_weight(
             [ScopedKey.from_str(network) for network in networks], weight
         )
+        return [str(network_sk) if network_sk else None for network_sk in network_sks]
     except Exception as e:
         raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -623,6 +623,14 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
         return status_counts
 
+    def get_networks_status(
+        self,
+        networks: List[ScopedKey],
+    ) -> List[Dict[str, int]]:
+        data = {"networks": [str(network) for network in networks]}
+        status_counts = self._post_resource("/bulk/networks/status", data=data)
+        return status_counts
+
     def get_transformation_status(
         self,
         transformation: ScopedKey,
@@ -679,6 +687,25 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
             return {ScopedKey.from_str(t): w for t, w in tasks.items()}
 
         return [ScopedKey.from_str(t) for t in tasks]
+
+    def get_networks_actioned_tasks(
+        self,
+        networks: List[ScopedKey],
+        task_weights: bool = False,
+    ) -> List[Union[Dict[ScopedKey, float], List[ScopedKey]]]:
+        data = dict(
+            networks=[str(network) for network in networks], task_weights=task_weights
+        )
+        grouped_tasks = self._post_resource("/bulk/networks/tasks/actioned", data=data)
+
+        return_data = []
+        for tasks in grouped_tasks:
+            if task_weights:
+                return_data.append({ScopedKey.from_str(t): w for t, w in tasks.items()})
+            else:
+                return_data.append([ScopedKey.from_str(t) for t in tasks])
+
+        return return_data
 
     def get_task_actioned_networks(
         self, task: ScopedKey, task_weights: bool = False

--- a/alchemiscale/interface/client.py
+++ b/alchemiscale/interface/client.py
@@ -228,7 +228,7 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
 
     def get_networks_weight(
         self, networks: List[ScopedKey], batch_size: int = 1000
-    ) -> [float]:
+    ) -> List[float]:
         return self._tokenizable_attribute_getter(
             networks, self._get_network_weight, batch_size
         )
@@ -848,7 +848,6 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
         tokenizables: List[ScopedKey],
         getter_function,
         batch_size,
-        should_return=True,
     ) -> List[Any]:
         tokenizables = [
             (
@@ -867,9 +866,6 @@ class AlchemiscaleClient(AlchemiscaleBaseClient):
                     for tokenizable_batch in self._batched(tokenizables, batch_size)
                 ]
             )
-
-            if not should_return:
-                return None
 
             return list(chain.from_iterable(values))
 

--- a/alchemiscale/storage/cypher.py
+++ b/alchemiscale/storage/cypher.py
@@ -16,6 +16,9 @@ def cypher_list_from_scoped_keys(scoped_keys: List[Optional[ScopedKey]]) -> str:
         Cypher list
     """
 
+    if not isinstance(scoped_keys, list):
+        raise ValueError("`scoped_keys` must be a list of ScopedKeys")
+
     data = []
     for scoped_key in scoped_keys:
         if scoped_key:

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -682,6 +682,8 @@ class TestClient:
 
         status_counts = user_client.get_networks_status(an_sks)
 
+        assert len(status_counts) == len(an_sks)
+
         for i, statuses in enumerate(status_counts):
             for status in statuses:
                 if status == "waiting":
@@ -813,9 +815,10 @@ class TestClient:
         all_task_sks = []
         for network_sk, transformation_sk in zip(network_sks, transformation_sks):
             task_sks = user_client.create_tasks(transformation_sk, count=n_tasks)
+
             # action all but one task for each network
-            user_client.action_tasks(task_sks[: n_tasks - 1], network_sk)
-            all_task_sks.append(task_sks[: n_tasks - 1])
+            actioned = user_client.action_tasks(task_sks[: n_tasks - 1], network_sk)
+            all_task_sks.append(actioned)
 
         results = user_client.get_networks_actioned_tasks(
             network_sks, task_weights=get_weights
@@ -830,9 +833,9 @@ class TestClient:
 
         for network_result, task_sks in zip(results, all_task_sks):
             if get_weights:
-                assert list(network_result.values()) == [0.5, 0.5]
+                assert list(network_result.values()) == [0.5] * (n_tasks - 1)
 
-            assert set(network_result) == set(task_sks[: n_tasks - 1])
+            assert set(network_result) == set(task_sks)
 
     @pytest.mark.parametrize(
         ("actioned_tasks"),

--- a/alchemiscale/tests/integration/interface/client/test_client.py
+++ b/alchemiscale/tests/integration/interface/client/test_client.py
@@ -336,6 +336,12 @@ class TestClient:
             user_client.set_network_weight(an_sk, weight)
             assert user_client.get_network_weight(an_sk) == weight
 
+            weight = abs(weight - 0.5)
+            result = user_client.set_network_weight(an_sk, weight)
+
+            assert result == an_sk
+            assert user_client.get_network_weight(an_sk) == weight
+
     @pytest.mark.parametrize(
         "weight, shouldfail",
         [
@@ -355,20 +361,20 @@ class TestClient:
         weight,
         shouldfail,
     ):
-        networks = [
-            network_tyk2.copy_with_replacements(
-                name=network_tyk2.name + "_test_set_networks_weight_{i}"
+
+        # create new networks and taskhubs
+        network_sks = []
+        for i in range(2):
+            network = network_tyk2.copy_with_replacements(
+                name=network_tyk2.name + f"_test_set_networks_weight_{i}"
             )
-            for i in range(2)
-        ]
 
-        network_sks = [
-            n4js_preloaded.create_network(network, scope_test) for network in networks
-        ]
-
-        for network_sk in network_sks:
+            network_sk = n4js_preloaded.create_network(network, scope_test)
             n4js_preloaded.create_taskhub(network_sk)
 
+            network_sks.append(network_sk)
+
+        # test for invalid input
         if shouldfail:
             with pytest.raises(
                 AlchemiscaleClientError,
@@ -377,7 +383,13 @@ class TestClient:
                 user_client.set_networks_weight(network_sks, weight)
         else:
             user_client.set_networks_weight(network_sks, weight)
-            assert n4js_preloaded.get_taskhub_weight(network_sks) == [weight] * 2
+            assert n4js_preloaded.get_taskhub_weight(network_sks) == [weight, weight]
+
+            weight = abs(weight - 0.5)
+            results = user_client.set_networks_weight(network_sks, weight)
+
+            assert results == network_sks
+            assert n4js_preloaded.get_taskhub_weight(network_sks) == [weight, weight]
 
     def test_get_transformation(
         self,

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -840,7 +840,7 @@ class TestNeo4jStore(TestStateStore):
         assert n["weight"] == 0.5
 
         # change the weight
-        n4js.set_taskhub_weight(network_sk, 0.7)
+        n4js.set_taskhub_weight([network_sk], 0.7)
 
         q = f"""match (n:TaskHub)
                 return n
@@ -937,7 +937,7 @@ class TestNeo4jStore(TestStateStore):
         """
 
         weight = n4js.execute_query(q).records[0].data()["taskhub.weight"]
-        weight_ = n4js.get_taskhub_weight(network_sk)
+        weight_ = n4js.get_taskhub_weight([network_sk])[0]
 
         assert weight == 0.5
         assert weight_ == 0.5
@@ -946,8 +946,8 @@ class TestNeo4jStore(TestStateStore):
         network_sk = n4js.create_network(network_tyk2, scope_test)
         n4js.create_taskhub(network_sk)
 
-        n4js.set_taskhub_weight(network_sk, 1.0)
-        weight = n4js.get_taskhub_weight(network_sk)
+        n4js.set_taskhub_weight([network_sk], 1.0)
+        weight = n4js.get_taskhub_weight([network_sk])[0]
 
         assert weight == 1.0
 

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -882,13 +882,13 @@ class TestNeo4jStore(TestStateStore):
         task_sks = [n4js.create_task(transformation_sk) for i in range(5)]
 
         # do not action the tasks yet; should get back nothing
-        actioned_tasks = n4js.get_taskhub_actioned_tasks(taskhub_sk)
+        actioned_tasks = n4js.get_taskhub_actioned_tasks([taskhub_sk])[0]
         assert actioned_tasks == {}
 
         # action 3 of 5 tasks
         n4js.action_tasks(task_sks[:3], taskhub_sk)
 
-        actioned_tasks = n4js.get_taskhub_actioned_tasks(taskhub_sk)
+        actioned_tasks = n4js.get_taskhub_actioned_tasks([taskhub_sk])[0]
 
         assert len(actioned_tasks) == 3
         assert all([task_i in task_sks for task_i in actioned_tasks])
@@ -1456,14 +1456,14 @@ class TestNeo4jStore(TestStateStore):
         for tf_sk in tf_sks:
             task_sks.append(n4js.create_task(tf_sk))
 
-        status = n4js.get_network_status(an_sk)
+        status = n4js.get_network_status([an_sk])[0]
         assert len(status) == 1
         assert status["waiting"] == len(task_sks)
 
         # change some task statuses
         n4js.set_task_invalid(task_sks[:10])
 
-        status = n4js.get_network_status(an_sk)
+        status = n4js.get_network_status([an_sk])[0]
         assert len(status) == 2
         assert status["waiting"] == len(task_sks) - 10
         assert status["invalid"] == 10

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -880,7 +880,7 @@ class TestNeo4jStore(TestStateStore):
         assert n["weight"] == 0.5
 
         # change the weight
-        n4js.set_taskhub_weight([network_sk], 0.7)
+        n4js.set_taskhub_weight([network_sk], [0.7])
 
         q = f"""match (n:TaskHub)
                 return n
@@ -986,7 +986,7 @@ class TestNeo4jStore(TestStateStore):
         network_sk = n4js.create_network(network_tyk2, scope_test)
         n4js.create_taskhub(network_sk)
 
-        results = n4js.set_taskhub_weight([network_sk], 1.0)
+        results = n4js.set_taskhub_weight([network_sk], [1.0])
         weight = n4js.get_taskhub_weight([network_sk])[0]
 
         assert results == [network_sk]
@@ -1002,13 +1002,13 @@ class TestNeo4jStore(TestStateStore):
             network_sks.append(network_sk)
             n4js.create_taskhub(network_sk)
 
-        results = n4js.set_taskhub_weight(network_sks, 1.0)
+        results = n4js.set_taskhub_weight(network_sks, [1.0] * 3)
         weight = n4js.get_taskhub_weight(network_sks)
 
         assert results == network_sks
         assert weight == [1.0, 1.0, 1.0]
 
-        results = n4js.set_taskhub_weight([network_sks[0]], 0.5)
+        results = n4js.set_taskhub_weight([network_sks[0]], [0.5])
         weight = n4js.get_taskhub_weight(network_sks)
 
         assert results == [network_sks[0]]
@@ -1017,7 +1017,7 @@ class TestNeo4jStore(TestStateStore):
         wrong_scoped_key = ScopedKey.from_str(str(network_sks[1]) + "noexist")
 
         results = n4js.set_taskhub_weight(
-            [network_sks[0], wrong_scoped_key, network_sks[2]], 0.25
+            [network_sks[0], wrong_scoped_key, network_sks[2]], [0.25] * 3
         )
         weight = n4js.get_taskhub_weight(
             [network_sks[0], wrong_scoped_key, network_sks[2]]
@@ -1025,6 +1025,11 @@ class TestNeo4jStore(TestStateStore):
 
         assert results == [network_sks[0], None, network_sks[2]]
         assert weight == [0.25, None, 0.25]
+
+        results = n4js.set_taskhub_weight(network_sks, [0.5, 0.3, 0.7])
+        weight = n4js.get_taskhub_weight(network_sks)
+
+        assert weight == [0.5, 0.3, 0.7]
 
     def test_action_task(self, n4js: Neo4jStore, network_tyk2, scope_test):
         an = network_tyk2

--- a/alchemiscale/tests/unit/test_cypher.py
+++ b/alchemiscale/tests/unit/test_cypher.py
@@ -1,0 +1,20 @@
+import pytest
+
+from alchemiscale.storage.cypher import cypher_list_from_scoped_keys
+
+
+def test_cypher_list_from_scoped_keys():
+
+    prefix = "FakeClass"
+    org = "FakeOrg"
+    campaign = "FakeCampaign"
+    project = "FakeProject"
+
+    sks = ["-".join((prefix, str(token), org, campaign, project)) for token in range(3)]
+
+    expected = '["FakeClass-0-FakeOrg-FakeCampaign-FakeProject", "FakeClass-1-FakeOrg-FakeCampaign-FakeProject", "FakeClass-2-FakeOrg-FakeCampaign-FakeProject"]'
+
+    assert cypher_list_from_scoped_keys(sks) == expected
+
+    with pytest.raises(ValueError, match="`scoped_keys` must be a list of ScopedKeys"):
+        cypher_list_from_scoped_keys(sks[0])


### PR DESCRIPTION
This PR introduces 

- [x] `get_networks_status`
- [x] `get_networks_actioned_tasks`
- [x] `get_networks_weight`
- [x] `set_networks_weight`

methods to the Alchemiscale client. The first two close #251 and the other two close #243.