### PR TITLE
Unimplemented tests marked with xfail

### DIFF
--- a/alchemiscale/tests/integration/compute/client/test_compute_service.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_service.py
@@ -98,10 +98,11 @@ class TestSynchronousComputeService:
 
         assert len(protocoldag.protocol_units) == 23
 
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_push_result(self):
         # already tested with with client test for `set_task_result`
         # expand this test when we have result path handling added in
-        ...
+        raise NotImplementedError
 
     def test_execute(
         self, n4js_preloaded, s3os_server_fresh, service, network_tyk2, scope_test
@@ -152,9 +153,13 @@ class TestSynchronousComputeService:
 
         assert results.records
 
-    def test_cycle_max_tasks(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_cycle_max_tasks(self):
+        raise NotImplementedError
 
-    def test_cycle_max_time(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_cycle_max_time(self):
+        raise NotImplementedError
 
     def test_start(self, n4js_preloaded, s3os_server_fresh, service):
         n4js: Neo4jStore = n4js_preloaded
@@ -190,16 +195,21 @@ class TestSynchronousComputeService:
         results = n4js.execute_query(q)
         assert results.records
 
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_stop(self):
         # tested as part of tests above to stop threaded components that
         # otherwise run forever
-        ...
+        raise NotImplementedError
 
     # init kwarg tests
 
-    def test_kwarg_keep_shared(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_kwarg_keep_shared(self):
+        raise NotImplementedError
 
-    def test_kwarg_keep_scratch(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_kwarg_keep_scratch(self):
+        raise NotImplementedError
 
     def test_kwarg_scopes(self):
         # TODO: add test here with alternative settings to `service` fixture

--- a/alchemiscale/tests/integration/interface/test_api.py
+++ b/alchemiscale/tests/integration/interface/test_api.py
@@ -138,30 +138,52 @@ class TestAPI:
         assert str(sk_unauthenticated.scope) in details
         assert str(auth_scope) in details
 
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_query_transformations(
         self, n4js_preloaded, network_tyk2, test_client, scope_test
-    ): ...
+    ):
+        raise NotImplementedError
 
-    def test_get_transformation(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_get_transformation(self):
+        raise NotImplementedError
 
-    def test_query_chemicalsystems(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_query_chemicalsystems(self):
+        raise NotImplementedError
 
-    def test_get_chemicalsystem(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_get_chemicalsystem(self):
+        raise NotImplementedError
 
     ### compute
 
-    def test_set_strategy(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_set_strategy(self):
+        raise NotImplementedError
 
-    def test_create_tasks(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_create_tasks(self):
+        raise NotImplementedError
 
-    def test_get_tasks(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_get_tasks(self):
+        raise NotImplementedError
 
-    def test_action_tasks(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_action_tasks(self):
+        raise NotImplementedError
 
-    def test_cancel_tasks(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_cancel_tasks(self):
+        raise NotImplementedError
 
     ### results
 
-    def test_get_transformation_results(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_get_transformation_results(self):
+        raise NotImplementedError
 
-    def test_get_protocoldagresult(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_get_protocoldagresult(self):
+        raise NotImplementedError

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -100,7 +100,9 @@ class TestNeo4jStore(TestStateStore):
 
         assert len(n3.records) == 2
 
-    def test_delete_network(self): ...
+    @pytest.mark.xfail(raises=NotImplementedError)
+    def test_delete_network(self):
+        raise NotImplementedError
 
     def test_get_network(self, n4js, network_tyk2, scope_test):
         an = network_tyk2


### PR DESCRIPTION
This PR clarifies which tests are unimplemented by using the pytest xfail mark.