### PR TITLE
Added support for `NonTransformation`s

### DIFF
--- a/alchemiscale/tests/integration/compute/conftest.py
+++ b/alchemiscale/tests/integration/compute/conftest.py
@@ -4,16 +4,15 @@ from collections import defaultdict
 import pytest
 from fastapi.testclient import TestClient
 
-from gufe import AlchemicalNetwork
+from gufe import AlchemicalNetwork, NonTransformation
 
 from alchemiscale.settings import get_base_api_settings
 from alchemiscale.storage.statestore import Neo4jStore
-from alchemiscale.compute import api, client
+from alchemiscale.compute import api
 from alchemiscale.security.models import CredentialedComputeIdentity, TokenData
 from alchemiscale.security.auth import hash_key
 from alchemiscale.base.api import (
     get_token_data_depends,
-    get_n4js_depends,
     get_s3os_depends,
 )
 
@@ -82,7 +81,9 @@ def n4js_preloaded(
     n4js: Neo4jStore = n4js_fresh
 
     # Set up tasks from select set of transformations
-    transformations = list(network_tyk2.edges)[0:3]
+    transformations = sorted(
+        filter(lambda x: type(x) is not NonTransformation, network_tyk2.edges)
+    )[0:3]
 
     # set starting contents for many of the tests in this module
     for single_scope in multiple_scopes:

--- a/alchemiscale/tests/integration/conftest.py
+++ b/alchemiscale/tests/integration/conftest.py
@@ -284,7 +284,7 @@ def network_tyk2():
 def get_edge_type(
     network: AlchemicalNetwork, edge_class
 ) -> Union[Transformation, NonTransformation]:
-    for tf in network.edges:
+    for tf in sorted(network.edges):
         if type(tf) is edge_class:
             return tf
     raise RuntimeError("Network does not contain a `{edge_class.__qualname__}`")

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -594,7 +594,7 @@ class TestNeo4jStore(TestStateStore):
         task_sk: ScopedKey = n4js.create_task(transformation_sk)
         q = f"""match (n:Task {{_gufe_key: '{task_sk.gufe_key}',
                                              _org: '{task_sk.org}', _campaign: '{task_sk.campaign}',
-                                             _project: '{task_sk.project}'}})-[:PERFORMS]->(m:Transformation)
+                                             _project: '{task_sk.project}'}})-[:PERFORMS]->(m:Transformation|NonTransformation)
                 return m
                 """
         m = n4js.execute_query(q).records[0]["m"]

--- a/alchemiscale/validators.py
+++ b/alchemiscale/validators.py
@@ -4,7 +4,7 @@
 
 """
 
-from gufe import AlchemicalNetwork, Transformation, NonTransformation
+from gufe import AlchemicalNetwork, Transformation
 
 
 def validate_network_nonself(network: AlchemicalNetwork):

--- a/alchemiscale/validators.py
+++ b/alchemiscale/validators.py
@@ -4,7 +4,7 @@
 
 """
 
-from gufe import AlchemicalNetwork, Transformation
+from gufe import AlchemicalNetwork, Transformation, NonTransformation
 
 
 def validate_network_nonself(network: AlchemicalNetwork):
@@ -15,7 +15,10 @@ def validate_network_nonself(network: AlchemicalNetwork):
 
     """
     for transformation in network.edges:
-        if transformation.stateA == transformation.stateB:
+        if (
+            type(transformation) is Transformation
+            and transformation.stateA == transformation.stateB
+        ):
             raise ValueError(
                 f"`Transformation` '{transformation.key}' uses the same `ChemicalSystem` '{transformation.stateA.key}' for both states; "
                 "this is currently not supported in `alchemiscale`"


### PR DESCRIPTION
This PR closes #110. The default `network_tyk2` fixture now includes `NonTransformation`s on all `ChemicalSystem`s. All Cypher queries involving `Transformation`s now also include `NonTransformation`s. Self loop validation now only runs when the transformation is of type `Transformation`.