### PR TITLE
Fix regular expression matching in `query_networks`

### DIFF
--- a/alchemiscale/storage/statestore.py
+++ b/alchemiscale/storage/statestore.py
@@ -856,19 +856,26 @@ class Neo4jStore(AlchemiscaleStateStore):
             gufe_key_pattern=None if key is None else str(key),
         )
 
-        for k, v in query_params.items():
-            if v is None:
-                query_params[k] = ".*"
+        where_params = dict(
+            name_pattern="an.name",
+            org_pattern="an.`_org`",
+            campaign_pattern="an.`_campaign`",
+            project_pattern="an.`_project`",
+            state_pattern="nm.state",
+            gufe_key_pattern="an.`_gufe_key`",
+        )
 
-        q = """
+        conditions = []
+
+        for k, v in query_params.items():
+            if v is not None:
+                conditions.append(f"{where_params[k]} =~ ${k}")
+
+        where_clause = "WHERE " + " AND ".join(conditions) if len(conditions) else ""
+
+        q = f"""
             MATCH (an:AlchemicalNetwork)<-[:MARKS]-(nm:NetworkMark)
-            WHERE
-                    an.name =~ $name_pattern
-                AND an.`_gufe_key` =~ $gufe_key_pattern
-                AND an.`_org` =~ $org_pattern
-                AND an.`_campaign` =~ $campaign_pattern
-                AND an.`_project` =~ $project_pattern
-                AND nm.state =~ $state_pattern
+            {where_clause}
             RETURN an._scoped_key as sk
         """
 

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -206,7 +206,7 @@ class TestNeo4jStore(TestStateStore):
 
     def test_query_networks(self, n4js, network_tyk2, scope_test, multiple_scopes):
         an = network_tyk2
-        an2 = AlchemicalNetwork(edges=list(an.edges)[:-2], name="incomplete")
+        an2 = AlchemicalNetwork(edges=list(an.edges)[:-2], name=None)
 
         sk: ScopedKey = n4js.assemble_network(an, scope_test)[0]
         sk2: ScopedKey = n4js.assemble_network(an2, scope_test)[0]


### PR DESCRIPTION
Since attributes of `GufeTokenizable`s that are set to None are not explicitly stored in the Neo4j database, regular expression fails to match nodes. Because of this, we no longer introduce wildcards when a attribute pattern is set to None. Instead, we completely remove that attribute regex condition from the WHERE clause.

The test for the `query_networks` method was also changed so a network without a name is included.

Closes #273 