### PR TITLE
Fix for create_network in interface API, properly deserializing AlchemicalNetwork

### DIFF
--- a/alchemiscale/tests/integration/compute/client/test_compute_client.py
+++ b/alchemiscale/tests/integration/compute/client/test_compute_client.py
@@ -162,10 +162,17 @@ class TestComputeClient:
 
         taskhub_sks = compute_client.query_taskhubs([scope_test])
 
+        remaining_tasks = n4js_preloaded.get_taskhub_unclaimed_tasks(taskhub_sks[0])
+        assert len(remaining_tasks) == 3
+
         # claim a single task; should get highest priority task
         task_sks = compute_client.claim_taskhub_tasks(
             taskhub_sks[0], compute_service_id=compute_service_id
         )
+
+        remaining_tasks = n4js_preloaded.get_taskhub_unclaimed_tasks(taskhub_sks[0])
+        assert len(remaining_tasks) == 2
+
         all_tasks = n4js_preloaded.get_taskhub_tasks(taskhub_sks[0], return_gufe=True)
 
         assert len(task_sks) == 1

--- a/alchemiscale/tests/integration/compute/conftest.py
+++ b/alchemiscale/tests/integration/compute/conftest.py
@@ -81,8 +81,10 @@ def n4js_preloaded(
     n4js: Neo4jStore = n4js_fresh
 
     # Set up tasks from select set of transformations
+    # we need to use second_network_an2 because its edges
+    # are a subset of network_tyk2's edges
     transformations = sorted(
-        filter(lambda x: type(x) is not NonTransformation, network_tyk2.edges)
+        filter(lambda x: type(x) is not NonTransformation, second_network_an2.edges)
     )[0:3]
 
     # set starting contents for many of the tests in this module


### PR DESCRIPTION
Directly handle the request to `create_network` using the gufe `JSON_HANDLER` to properly decode the contained `Settings` objects.

Since these changes also work with `gufe < 1.x.x`, this PR shouldn't be blocked by #254.