### PR TITLE
Increment compute env to use cudatoolkit 11.8

### DIFF
--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - pip
   - python =3.10
-  - cudatoolkit <=11.7  # many actual compute resources are not yet compatible with cudatoolkit >=11.8
+  - cudatoolkit =11.8  # many actual compute resources are not yet compatible with cudatoolkit >=11.8
 
   # alchemiscale dependencies
   - gufe=0.9.5

--- a/devtools/conda-envs/alchemiscale-compute.yml
+++ b/devtools/conda-envs/alchemiscale-compute.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - pip
   - python =3.10
-  - cudatoolkit =11.8  # many actual compute resources are not yet compatible with cudatoolkit >=11.8
+  - cudatoolkit =11.8
 
   # alchemiscale dependencies
   - gufe=0.9.5


### PR DESCRIPTION
We've experienced frequent errors with using OpenMM 8.1.1:

    openmm.OpenMMException: Error initializing FFT: 5

and the culprint may be `cudatoolkit` 11.7: https://github.com/pytorch/pytorch/issues/88038

In an attempt to address this, pinning to the latest `cudatoolkit` available on `conda-forge` as of this writing (11.8) to see if these errors drop in frequency.
