### PR TITLE
Test TaskHub Task claiming by Protocol

### DIFF
--- a/alchemiscale/tests/integration/conftest.py
+++ b/alchemiscale/tests/integration/conftest.py
@@ -221,6 +221,20 @@ def s3os(s3objectstore_settings):
 
 # test alchemical networks
 
+
+## define varying protocols to simulate protocol variety
+class DummyProtocolA(DummyProtocol):
+    pass
+
+
+class DummyProtocolB(DummyProtocol):
+    pass
+
+
+class DummyProtocolC(DummyProtocol):
+    pass
+
+
 # TODO: add in atom mapping once `gufe`#35 is settled
 
 
@@ -251,7 +265,7 @@ def network_tyk2():
         Transformation(
             stateA=complexes[edge[0]],
             stateB=complexes[edge[1]],
-            protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
+            protocol=DummyProtocolA(settings=DummyProtocolA.default_settings()),
             name=f"{edge[0]}_to_{edge[1]}_complex",
         )
         for edge in tyk2s.connections
@@ -260,7 +274,7 @@ def network_tyk2():
         Transformation(
             stateA=solvated[edge[0]],
             stateB=solvated[edge[1]],
-            protocol=DummyProtocol(settings=DummyProtocol.default_settings()),
+            protocol=DummyProtocolB(settings=DummyProtocolB.default_settings()),
             name=f"{edge[0]}_to_{edge[1]}_solvent",
         )
         for edge in tyk2s.connections
@@ -270,7 +284,7 @@ def network_tyk2():
     for cs in list(solvated.values()) + list(complexes.values()):
         nt = NonTransformation(
             system=cs,
-            protocol=DummyProtocol(DummyProtocol.default_settings()),
+            protocol=DummyProtocolC(DummyProtocolC.default_settings()),
             name=f"f{cs.name}_nt",
         )
         nontransformations.append(nt)

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -1324,6 +1324,55 @@ class TestNeo4jStore(TestStateStore):
         claimed6 = n4js.claim_taskhub_tasks(taskhub_sk, csid, count=2)
         assert claimed6 == [None] * 2
 
+    def test_claim_taskhub_tasks_protocol_split(
+        self, n4js: Neo4jStore, network_tyk2, scope_test
+    ):
+        an = network_tyk2
+        network_sk, taskhub_sk, _ = n4js.assemble_network(an, scope_test)
+
+        from ..conftest import DummyProtocolA, DummyProtocolB, DummyProtocolC
+        from functools import reduce
+
+        def reducer(collection, transformation):
+            protocol = transformation.protocol.__class__
+            if len(collection[protocol]) >= 3:
+                return collection
+            sk = n4js.get_scoped_key(transformation, scope_test)
+            collection[transformation.protocol.__class__].append(sk)
+            return collection
+
+        transformations = reduce(
+            reducer,
+            an.edges,
+            {DummyProtocolA: [], DummyProtocolB: [], DummyProtocolC: []},
+        )
+
+        transformation_sks = [
+            value for _, values in transformations.items() for value in values
+        ]
+
+        task_sks = n4js.create_tasks(transformation_sks)
+        assert len(task_sks) == 9
+
+        # action the tasks
+        n4js.action_tasks(task_sks, taskhub_sk)
+        assert len(n4js.get_taskhub_unclaimed_tasks(taskhub_sk)) == 9
+
+        csid = ComputeServiceID("another task handler")
+        n4js.register_computeservice(ComputeServiceRegistration.from_now(csid))
+
+        claimedA = n4js.claim_taskhub_tasks(
+            taskhub_sk, csid, protocols=["DummyProtocolA"], count=9
+        )
+
+        assert len([sk for sk in claimedA if sk]) == 3
+
+        claimedBC = n4js.claim_taskhub_tasks(
+            taskhub_sk, csid, protocols=["DummyProtocolB", "DummyProtocolC"], count=9
+        )
+
+        assert len([sk for sk in claimedBC if sk]) == 6
+
     def test_claim_taskhub_tasks_deregister(
         self, n4js: Neo4jStore, network_tyk2, scope_test
     ):

--- a/alchemiscale/tests/integration/storage/test_statestore.py
+++ b/alchemiscale/tests/integration/storage/test_statestore.py
@@ -3,6 +3,7 @@ import random
 from typing import List, Dict
 from pathlib import Path
 from itertools import chain
+from functools import reduce
 
 import pytest
 from gufe import AlchemicalNetwork
@@ -26,6 +27,8 @@ from alchemiscale.security.models import (
     CredentialedComputeIdentity,
 )
 from alchemiscale.security.auth import hash_key
+
+from ..conftest import DummyProtocolA, DummyProtocolB, DummyProtocolC
 
 
 class TestStateStore: ...
@@ -1329,9 +1332,6 @@ class TestNeo4jStore(TestStateStore):
     ):
         an = network_tyk2
         network_sk, taskhub_sk, _ = n4js.assemble_network(an, scope_test)
-
-        from ..conftest import DummyProtocolA, DummyProtocolB, DummyProtocolC
-        from functools import reduce
 
         def reducer(collection, transformation):
             protocol = transformation.protocol.__class__


### PR DESCRIPTION
* Minor changes to new claiming code (cypher query generation fails when provided a `Protocol` instance)
* Introduce a new set of `DummyProtocol` subclasses
* Test `Task` claiming with a `Protocol` list