### PR TITLE
Set default `claim_limit` back to 1

### DIFF
--- a/alchemiscale/compute/settings.py
+++ b/alchemiscale/compute/settings.py
@@ -61,7 +61,7 @@ class ComputeServiceSettings(BaseModel):
         description="Names of Protocols to run with this service; `None` means no restriction.",
     )
     claim_limit: int = Field(
-        1000, description="Maximum number of Tasks to claim at a time from a TaskHub."
+        1, description="Maximum number of Tasks to claim at a time from a TaskHub."
     )
     loglevel: str = Field(
         "WARN",


### PR DESCRIPTION
It appears we accidentally changed the default `claim_limit` for compute services to 1000, which massively changes the behavior for deployed compute services if they don't explicitly set this option in their configuration files.

This changes this default back to 1.
