### PR TITLE
Bumping CI Neo4j version to 5.19

### DIFF
--- a/alchemiscale/tests/integration/conftest.py
+++ b/alchemiscale/tests/integration/conftest.py
@@ -103,7 +103,7 @@ class TestProfile:
 
 # TODO: test with full certificates
 neo4j_deployment_profiles = [
-    DeploymentProfile(release=(5, 16), topology="CE", schemes=["bolt"]),
+    DeploymentProfile(release=(5, 19), topology="CE", schemes=["bolt"]),
 ]
 
 if NEO4J_VERSION == "LATEST":


### PR DESCRIPTION
grolt or py2neo fails with neo4j >= 5.19